### PR TITLE
feat: display contributor username on list and detail pages

### DIFF
--- a/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/catalog/application/IngredientService.java
+++ b/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/catalog/application/IngredientService.java
@@ -5,6 +5,7 @@ import com.yaseminyumak.culinarygraphbackend.catalog.domain.Ingredient;
 import com.yaseminyumak.culinarygraphbackend.catalog.domain.IngredientRepository;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -84,9 +85,9 @@ public class IngredientService {
 
 	private static String getCurrentUserId() {
 		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-		if (auth != null && auth.isAuthenticated() && auth.getPrincipal() != null
-			&& !"anonymousUser".equals(auth.getPrincipal().toString())) {
-			return auth.getName();
+		if (auth instanceof JwtAuthenticationToken jwtAuth) {
+			String username = jwtAuth.getToken().getClaimAsString("preferred_username");
+			if (username != null && !username.isBlank()) return username;
 		}
 		return "local-dev-user";
 	}

--- a/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/catalog/application/TechniqueService.java
+++ b/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/catalog/application/TechniqueService.java
@@ -6,6 +6,7 @@ import com.yaseminyumak.culinarygraphbackend.catalog.domain.TechniqueRepository;
 import com.yaseminyumak.culinarygraphbackend.catalog.domain.TechniqueStep;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -99,9 +100,9 @@ public class TechniqueService {
 
 	private static String getCurrentUserId() {
 		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-		if (auth != null && auth.isAuthenticated() && auth.getPrincipal() != null
-			&& !"anonymousUser".equals(auth.getPrincipal().toString())) {
-			return auth.getName();
+		if (auth instanceof JwtAuthenticationToken jwtAuth) {
+			String username = jwtAuth.getToken().getClaimAsString("preferred_username");
+			if (username != null && !username.isBlank()) return username;
 		}
 		return "local-dev-user";
 	}

--- a/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/recipe/application/RecipeService.java
+++ b/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/recipe/application/RecipeService.java
@@ -4,6 +4,7 @@ import com.yaseminyumak.culinarygraphbackend.recipe.api.dto.CreateRecipeRequest;
 import com.yaseminyumak.culinarygraphbackend.recipe.domain.*;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.HashSet;
@@ -96,11 +97,10 @@ public class RecipeService {
 
 	private static String getCurrentUserId() {
 		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-		if (auth != null && auth.isAuthenticated() && auth.getPrincipal() != null
-			&& !"anonymousUser".equals(auth.getPrincipal().toString())) {
-			return auth.getName();
+		if (auth instanceof JwtAuthenticationToken jwtAuth) {
+			String username = jwtAuth.getToken().getClaimAsString("preferred_username");
+			if (username != null && !username.isBlank()) return username;
 		}
-		// Local / dev: no JWT or anonymous -> use fallback so POST /api/recipes works
 		return "local-dev-user";
 	}
 }

--- a/culinarygraph-frontend/src/features/catalog/IngredientDetailPage.tsx
+++ b/culinarygraph-frontend/src/features/catalog/IngredientDetailPage.tsx
@@ -124,6 +124,14 @@ export default function IngredientDetailPage() {
             </ul>
           </div>
         )}
+
+        {ingredient.createdBy && (
+          <div className="pt-4 border-t border-gray-100">
+            <p className="text-xs text-gray-400">
+              Created by <span className="font-medium text-[#8c2d9c]">{ingredient.createdBy}</span>
+            </p>
+          </div>
+        )}
       </div>
 
     </div>

--- a/culinarygraph-frontend/src/features/catalog/IngredientListPage.tsx
+++ b/culinarygraph-frontend/src/features/catalog/IngredientListPage.tsx
@@ -154,6 +154,9 @@ export default function IngredientListPage() {
                     <p className="text-xs text-gray-400 mt-1">
                       {[ing.country, ing.region].filter(Boolean).join(', ') || 'No region'}
                     </p>
+                    {ing.createdBy && (
+                      <p className="text-xs text-gray-400 mt-2">By {ing.createdBy}</p>
+                    )}
                   </div>
                 </Link>
               ))}

--- a/culinarygraph-frontend/src/features/catalog/TechniqueDetailPage.tsx
+++ b/culinarygraph-frontend/src/features/catalog/TechniqueDetailPage.tsx
@@ -142,6 +142,14 @@ export default function TechniqueDetailPage() {
             </ul>
           </div>
         )}
+
+        {technique.createdBy && (
+          <div className="pt-4 border-t border-gray-100">
+            <p className="text-xs text-gray-400">
+              Created by <span className="font-medium text-[#8c2d9c]">{technique.createdBy}</span>
+            </p>
+          </div>
+        )}
       </div>
     </div>
     </>

--- a/culinarygraph-frontend/src/features/catalog/TechniqueListPage.tsx
+++ b/culinarygraph-frontend/src/features/catalog/TechniqueListPage.tsx
@@ -153,6 +153,9 @@ export default function TechniqueListPage() {
                     {(t.country || t.region) && (
                       <p className="text-xs text-[#8c2d9c] mt-1 font-medium">{[t.country, t.region].filter(Boolean).join(', ')}</p>
                     )}
+                    {t.createdBy && (
+                      <p className="text-xs text-gray-400 mt-2">By {t.createdBy}</p>
+                    )}
                   </div>
                 </Link>
               ))}

--- a/culinarygraph-frontend/src/features/recipe/RecipeDetailPage.tsx
+++ b/culinarygraph-frontend/src/features/recipe/RecipeDetailPage.tsx
@@ -146,6 +146,14 @@ export default function RecipeDetailPage() {
             </p>
           </div>
         )}
+
+        {recipe.createdBy && (
+          <div className="pt-4 border-t border-gray-100">
+            <p className="text-xs text-gray-400">
+              Created by <span className="font-medium text-[#8c2d9c]">{recipe.createdBy}</span>
+            </p>
+          </div>
+        )}
       </div>
     </div>
     </>

--- a/culinarygraph-frontend/src/features/recipe/RecipeListPage.tsx
+++ b/culinarygraph-frontend/src/features/recipe/RecipeListPage.tsx
@@ -264,6 +264,9 @@ export default function RecipeListPage() {
                     {(r.country || r.region) && (
                       <p className="text-xs text-[#8c2d9c] mt-1 font-medium">{[r.country, r.region].filter(Boolean).join(', ')}</p>
                     )}
+                    {r.createdBy && (
+                      <p className="text-xs text-gray-400 mt-2">By {r.createdBy}</p>
+                    )}
                   </div>
                 </Link>
               ))}


### PR DESCRIPTION
Backend services now extract preferred_username from the JWT instead of                                                          
  the Keycloak UUID sub-claim. All three list page cards show "By <username>"                                                      
  and all three detail pages show "Created by <username>" before the comments                                                      
  section.
  
  closes #46 