### PR TITLE
fix: enforce content ownership for edit and delete operations

### DIFF
--- a/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/catalog/application/IngredientService.java
+++ b/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/catalog/application/IngredientService.java
@@ -3,11 +3,13 @@ package com.yaseminyumak.culinarygraphbackend.catalog.application;
 import com.yaseminyumak.culinarygraphbackend.catalog.api.dto.CreateIngredientRequest;
 import com.yaseminyumak.culinarygraphbackend.catalog.domain.Ingredient;
 import com.yaseminyumak.culinarygraphbackend.catalog.domain.IngredientRepository;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.HashSet;
 import java.util.List;
@@ -54,6 +56,7 @@ public class IngredientService {
 	@Transactional
 	public Ingredient update(UUID id, CreateIngredientRequest request) {
 		Ingredient ingredient = getById(id);
+		requireOwner(ingredient.getCreatedBy());
 		ingredient.update(
 			request.name(), request.description(), request.region(),
 			request.seasons() != null ? new HashSet<>(request.seasons()) : new HashSet<>(),
@@ -66,6 +69,7 @@ public class IngredientService {
 	@Transactional
 	public void delete(UUID id) {
 		Ingredient ingredient = getById(id);
+		requireOwner(ingredient.getCreatedBy());
 		ingredientRepository.delete(ingredient);
 	}
 
@@ -81,6 +85,12 @@ public class IngredientService {
 		Ingredient ingredient = getById(id);
 		ingredient.archive();
 		return ingredientRepository.save(ingredient);
+	}
+
+	private static void requireOwner(String createdBy) {
+		if (!createdBy.equals(getCurrentUserId())) {
+			throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only the creator can modify this content");
+		}
 	}
 
 	private static String getCurrentUserId() {

--- a/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/catalog/application/TechniqueService.java
+++ b/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/catalog/application/TechniqueService.java
@@ -4,11 +4,13 @@ import com.yaseminyumak.culinarygraphbackend.catalog.api.dto.CreateTechniqueRequ
 import com.yaseminyumak.culinarygraphbackend.catalog.domain.Technique;
 import com.yaseminyumak.culinarygraphbackend.catalog.domain.TechniqueRepository;
 import com.yaseminyumak.culinarygraphbackend.catalog.domain.TechniqueStep;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.HashSet;
 import java.util.List;
@@ -63,6 +65,7 @@ public class TechniqueService {
 	@Transactional
 	public Technique update(UUID id, CreateTechniqueRequest request) {
 		Technique technique = getById(id);
+		requireOwner(technique.getCreatedBy());
 		List<TechniqueStep> steps = request.steps() != null
 			? request.steps().stream()
 				.map(s -> new TechniqueStep(s.order(), s.instruction()))
@@ -81,6 +84,7 @@ public class TechniqueService {
 	@Transactional
 	public void delete(UUID id) {
 		Technique technique = getById(id);
+		requireOwner(technique.getCreatedBy());
 		techniqueRepository.delete(technique);
 	}
 
@@ -96,6 +100,12 @@ public class TechniqueService {
 		Technique technique = getById(id);
 		technique.archive();
 		return techniqueRepository.save(technique);
+	}
+
+	private static void requireOwner(String createdBy) {
+		if (!createdBy.equals(getCurrentUserId())) {
+			throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only the creator can modify this content");
+		}
 	}
 
 	private static String getCurrentUserId() {

--- a/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/recipe/application/RecipeService.java
+++ b/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/recipe/application/RecipeService.java
@@ -2,11 +2,13 @@ package com.yaseminyumak.culinarygraphbackend.recipe.application;
 
 import com.yaseminyumak.culinarygraphbackend.recipe.api.dto.CreateRecipeRequest;
 import com.yaseminyumak.culinarygraphbackend.recipe.domain.*;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -61,6 +63,7 @@ public class RecipeService {
 	@Transactional
 	public Recipe update(UUID id, CreateRecipeRequest request) {
 		Recipe recipe = getById(id);
+		requireOwner(recipe.getCreatedBy());
 		List<RecipeStep> steps = request.steps().stream()
 			.map(s -> new RecipeStep(s.order(), s.instruction()))
 			.collect(Collectors.toList());
@@ -78,6 +81,7 @@ public class RecipeService {
 	@Transactional
 	public void delete(UUID id) {
 		Recipe recipe = getById(id);
+		requireOwner(recipe.getCreatedBy());
 		recipeRepository.delete(recipe);
 	}
 
@@ -93,6 +97,12 @@ public class RecipeService {
 		Recipe recipe = getById(id);
 		recipe.archive();
 		return recipeRepository.save(recipe);
+	}
+
+	private static void requireOwner(String createdBy) {
+		if (!createdBy.equals(getCurrentUserId())) {
+			throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only the creator can modify this content");
+		}
 	}
 
 	private static String getCurrentUserId() {

--- a/culinarygraph-frontend/src/features/catalog/IngredientDetailPage.tsx
+++ b/culinarygraph-frontend/src/features/catalog/IngredientDetailPage.tsx
@@ -10,7 +10,7 @@ import { useAuth } from '../../auth/AuthProvider'
 export default function IngredientDetailPage() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
-  const { isAuthenticated } = useAuth()
+  const { isAuthenticated, keycloak } = useAuth()
   const queryClient = useQueryClient()
   const [showConfirm, setShowConfirm] = useState(false)
   const { techniqueById } = useCatalogIndex()
@@ -41,6 +41,7 @@ export default function IngredientDetailPage() {
     ...linkedTechniqueIds,
   ])]
   const location = [ingredient.country, ingredient.region].filter(Boolean).join(', ')
+  const canEdit = isAuthenticated && ingredient.createdBy === keycloak.tokenParsed?.preferred_username
 
   return (
     <>
@@ -54,13 +55,13 @@ export default function IngredientDetailPage() {
     <div className="max-w-3xl mx-auto px-6 py-8">
 
       {/* Image gallery */}
-      <ImageManager entityType="INGREDIENT" entityId={ingredient.id} />
+      <ImageManager entityType="INGREDIENT" entityId={ingredient.id} canEdit={canEdit} />
 
       {/* Title + meta */}
       <div className="mt-6 mb-6">
         <div className="flex items-start justify-between gap-4">
           <h1 className="text-2xl font-bold text-[#171433]">{ingredient.name}</h1>
-          {isAuthenticated && (
+          {canEdit && (
             <div className="flex gap-2 flex-shrink-0">
               <button onClick={() => navigate(`/catalog/ingredients/${id}/edit`)}
                 className="px-3 py-1.5 text-sm font-medium border border-[#8c2d9c] text-[#8c2d9c] rounded hover:bg-[#ede8ee] transition-colors">

--- a/culinarygraph-frontend/src/features/catalog/IngredientFormPage.tsx
+++ b/culinarygraph-frontend/src/features/catalog/IngredientFormPage.tsx
@@ -88,7 +88,7 @@ export default function IngredientFormPage() {
       <h1 className="text-xl font-bold text-[#171433]">{isEdit ? 'Edit Ingredient' : 'New Ingredient'}</h1>
       <hr className="my-3 border-[#d67ec9]" />
 
-      {isEdit && existing?.createdBy === keycloak?.subject && (
+      {isEdit && existing?.createdBy === keycloak?.tokenParsed?.preferred_username && (
         <div className="mb-6">
           <label className="block text-sm font-medium text-gray-700 mb-2">Photos</label>
           <ImageManager entityType="INGREDIENT" entityId={id!} canEdit={true} />

--- a/culinarygraph-frontend/src/features/catalog/TechniqueDetailPage.tsx
+++ b/culinarygraph-frontend/src/features/catalog/TechniqueDetailPage.tsx
@@ -10,7 +10,7 @@ import { useAuth } from '../../auth/AuthProvider'
 export default function TechniqueDetailPage() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
-  const { isAuthenticated } = useAuth()
+  const { isAuthenticated, keycloak } = useAuth()
   const queryClient = useQueryClient()
   const [showConfirm, setShowConfirm] = useState(false)
   const { ingredientById, techniqueById } = useCatalogIndex()
@@ -30,6 +30,7 @@ export default function TechniqueDetailPage() {
   if (error || !technique) return <p className="text-center py-16 text-sm text-red-500">Technique not found.</p>
 
   const location = [technique.country, technique.region].filter(Boolean).join(', ')
+  const canEdit = isAuthenticated && technique.createdBy === keycloak.tokenParsed?.preferred_username
 
   return (
     <>
@@ -43,13 +44,13 @@ export default function TechniqueDetailPage() {
     <div className="max-w-3xl mx-auto px-6 py-8">
 
       {/* Image gallery */}
-      <ImageManager entityType="TECHNIQUE" entityId={technique.id} />
+      <ImageManager entityType="TECHNIQUE" entityId={technique.id} canEdit={canEdit} />
 
       {/* Title + meta */}
       <div className="mt-6 mb-2">
         <div className="flex items-start justify-between gap-4">
           <h1 className="text-2xl font-bold text-[#171433]">{technique.name}</h1>
-          {isAuthenticated && (
+          {canEdit && (
             <div className="flex gap-2 flex-shrink-0">
               <button onClick={() => navigate(`/catalog/techniques/${id}/edit`)}
                 className="px-3 py-1.5 text-sm font-medium border border-[#8c2d9c] text-[#8c2d9c] rounded hover:bg-[#ede8ee] transition-colors">

--- a/culinarygraph-frontend/src/features/catalog/TechniqueFormPage.tsx
+++ b/culinarygraph-frontend/src/features/catalog/TechniqueFormPage.tsx
@@ -87,7 +87,7 @@ export default function TechniqueFormPage() {
       <h1 className="text-xl font-bold text-[#171433]">{isEdit ? 'Edit Technique' : 'New Technique'}</h1>
       <hr className="my-3 border-[#d67ec9]" />
 
-      {isEdit && existing?.createdBy === keycloak?.subject && (
+      {isEdit && existing?.createdBy === keycloak?.tokenParsed?.preferred_username && (
         <div className="mb-6">
           <label className="block text-sm font-medium text-gray-700 mb-2">Photos</label>
           <ImageManager entityType="TECHNIQUE" entityId={id!} canEdit={true} />

--- a/culinarygraph-frontend/src/features/recipe/RecipeDetailPage.tsx
+++ b/culinarygraph-frontend/src/features/recipe/RecipeDetailPage.tsx
@@ -10,7 +10,7 @@ import { useAuth } from '../../auth/AuthProvider'
 export default function RecipeDetailPage() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
-  const { isAuthenticated } = useAuth()
+  const { isAuthenticated, keycloak } = useAuth()
   const queryClient = useQueryClient()
   const [showConfirm, setShowConfirm] = useState(false)
   const { data: recipe, isLoading, error } = useQuery({
@@ -29,6 +29,7 @@ export default function RecipeDetailPage() {
   if (error || !recipe) return <p className="text-center py-16 text-sm text-red-500">Recipe not found.</p>
 
   const location = [recipe.country, recipe.region].filter(Boolean).join(', ')
+  const canEdit = isAuthenticated && recipe.createdBy === keycloak.tokenParsed?.preferred_username
 
   return (
     <>
@@ -42,13 +43,13 @@ export default function RecipeDetailPage() {
     <div className="max-w-3xl mx-auto px-6 py-8">
 
       {/* Image gallery */}
-      <ImageManager entityType="RECIPE" entityId={recipe.id} />
+      <ImageManager entityType="RECIPE" entityId={recipe.id} canEdit={canEdit} />
 
       {/* Title + meta */}
       <div className="mt-6 mb-6">
         <div className="flex items-start justify-between gap-4">
           <h1 className="text-2xl font-bold text-[#171433]">{recipe.title}</h1>
-          {isAuthenticated && (
+          {canEdit && (
             <div className="flex gap-2 flex-shrink-0">
               <button onClick={() => navigate(`/recipes/${id}/edit`)}
                 className="px-3 py-1.5 text-sm font-medium border border-[#8c2d9c] text-[#8c2d9c] rounded hover:bg-[#ede8ee] transition-colors">

--- a/culinarygraph-frontend/src/features/recipe/RecipeFormPage.tsx
+++ b/culinarygraph-frontend/src/features/recipe/RecipeFormPage.tsx
@@ -108,7 +108,7 @@ export default function RecipeFormPage() {
       <h1 className="text-xl font-bold text-[#171433]">{isEdit ? 'Edit Recipe' : 'New Recipe'}</h1>
       <hr className="my-3 border-[#d67ec9]" />
 
-      {isEdit && existing?.createdBy === keycloak?.subject && (
+      {isEdit && existing?.createdBy === keycloak?.tokenParsed?.preferred_username && (
         <div className="mb-6">
           <label className="block text-sm font-medium text-gray-700 mb-2">Photos</label>
           <ImageManager entityType="RECIPE" entityId={id!} canEdit={true} />


### PR DESCRIPTION
Backend services now reject PUT/DELETE requests from non-owners with                                                             
  403 FORBIDDEN. Frontend detail pages gate Edit/Delete buttons and photo                                                          
  management behind an ownership check (createdBy === preferred_username).                                                         
  Also fixes a broken keycloak.subject comparison in form pages that was                                                           
  preventing photo upload from working in edit mode.

Closes #45 