### PR TITLE
feat: add likes and comments for recipes, ingredients, and techniques

### DIFF
--- a/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/api/CommentController.java
+++ b/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/api/CommentController.java
@@ -1,0 +1,54 @@
+package com.yaseminyumak.culinarygraphbackend.social.api;
+
+import com.yaseminyumak.culinarygraphbackend.social.api.dto.AddCommentRequest;
+import com.yaseminyumak.culinarygraphbackend.social.api.dto.CommentResponse;
+import com.yaseminyumak.culinarygraphbackend.social.application.CommentService;
+import com.yaseminyumak.culinarygraphbackend.social.domain.CommentNotFoundException;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/social/comments")
+public class CommentController {
+
+	private final CommentService commentService;
+
+	public CommentController(CommentService commentService) {
+		this.commentService = commentService;
+	}
+
+	@GetMapping
+	public List<CommentResponse> list(@RequestParam String entityType, @RequestParam UUID entityId) {
+		return commentService.getComments(entityType, entityId).stream()
+			.map(c -> new CommentResponse(c.getId().toString(), c.getUsername(), c.getBody(), c.getCreatedAt().toString()))
+			.toList();
+	}
+
+	@PostMapping
+	@ResponseStatus(HttpStatus.CREATED)
+	public CommentResponse add(@Valid @RequestBody AddCommentRequest request) {
+		var c = commentService.addComment(request.entityType(), UUID.fromString(request.entityId()), request.body());
+		return new CommentResponse(c.getId().toString(), c.getUsername(), c.getBody(), c.getCreatedAt().toString());
+	}
+
+	@DeleteMapping("/{id}")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void delete(@PathVariable UUID id) {
+		commentService.deleteComment(id);
+	}
+
+	@GetMapping("/mine")
+	public List<CommentResponse> mine() {
+		return commentService.getMyComments().stream()
+			.map(c -> new CommentResponse(c.getId().toString(), c.getUsername(), c.getBody(), c.getCreatedAt().toString()))
+			.toList();
+	}
+
+	@ExceptionHandler(CommentNotFoundException.class)
+	@ResponseStatus(HttpStatus.NOT_FOUND)
+	public void handleNotFound() {}
+}

--- a/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/api/LikeController.java
+++ b/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/api/LikeController.java
@@ -1,0 +1,41 @@
+package com.yaseminyumak.culinarygraphbackend.social.api;
+
+import com.yaseminyumak.culinarygraphbackend.social.api.dto.LikedEntityResponse;
+import com.yaseminyumak.culinarygraphbackend.social.api.dto.LikeStatusResponse;
+import com.yaseminyumak.culinarygraphbackend.social.api.dto.ToggleLikeRequest;
+import com.yaseminyumak.culinarygraphbackend.social.application.LikeService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/social/likes")
+public class LikeController {
+
+	private final LikeService likeService;
+
+	public LikeController(LikeService likeService) {
+		this.likeService = likeService;
+	}
+
+	@GetMapping
+	public LikeStatusResponse getStatus(@RequestParam String entityType, @RequestParam UUID entityId) {
+		LikeService.LikeStatus status = likeService.getStatus(entityType, entityId);
+		return new LikeStatusResponse(status.count(), status.likedByMe());
+	}
+
+	@PostMapping
+	public LikeStatusResponse toggle(@Valid @RequestBody ToggleLikeRequest request) {
+		LikeService.LikeStatus status = likeService.toggle(request.entityType(), UUID.fromString(request.entityId()));
+		return new LikeStatusResponse(status.count(), status.likedByMe());
+	}
+
+	@GetMapping("/mine")
+	public List<LikedEntityResponse> mine() {
+		return likeService.getMyLikes().stream()
+			.map(l -> new LikedEntityResponse(l.getEntityType(), l.getEntityId().toString()))
+			.toList();
+	}
+}

--- a/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/api/dto/AddCommentRequest.java
+++ b/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/api/dto/AddCommentRequest.java
@@ -1,0 +1,10 @@
+package com.yaseminyumak.culinarygraphbackend.social.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record AddCommentRequest(
+	@NotBlank String entityType,
+	@NotNull String entityId,
+	@NotBlank String body
+) {}

--- a/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/api/dto/CommentResponse.java
+++ b/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/api/dto/CommentResponse.java
@@ -1,0 +1,3 @@
+package com.yaseminyumak.culinarygraphbackend.social.api.dto;
+
+public record CommentResponse(String id, String username, String body, String createdAt) {}

--- a/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/api/dto/LikeStatusResponse.java
+++ b/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/api/dto/LikeStatusResponse.java
@@ -1,0 +1,3 @@
+package com.yaseminyumak.culinarygraphbackend.social.api.dto;
+
+public record LikeStatusResponse(long count, boolean likedByMe) {}

--- a/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/api/dto/LikedEntityResponse.java
+++ b/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/api/dto/LikedEntityResponse.java
@@ -1,0 +1,3 @@
+package com.yaseminyumak.culinarygraphbackend.social.api.dto;
+
+public record LikedEntityResponse(String entityType, String entityId) {}

--- a/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/api/dto/ToggleLikeRequest.java
+++ b/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/api/dto/ToggleLikeRequest.java
@@ -1,0 +1,9 @@
+package com.yaseminyumak.culinarygraphbackend.social.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ToggleLikeRequest(
+	@NotBlank String entityType,
+	@NotNull String entityId
+) {}

--- a/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/application/CommentService.java
+++ b/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/application/CommentService.java
@@ -1,0 +1,68 @@
+package com.yaseminyumak.culinarygraphbackend.social.application;
+
+import com.yaseminyumak.culinarygraphbackend.social.domain.Comment;
+import com.yaseminyumak.culinarygraphbackend.social.domain.CommentNotFoundException;
+import com.yaseminyumak.culinarygraphbackend.social.domain.CommentRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class CommentService {
+
+	private final CommentRepository commentRepository;
+
+	public CommentService(CommentRepository commentRepository) {
+		this.commentRepository = commentRepository;
+	}
+
+	@Transactional(readOnly = true)
+	public List<Comment> getComments(String entityType, UUID entityId) {
+		return commentRepository.findByEntityTypeAndEntityId(entityType, entityId);
+	}
+
+	@Transactional
+	public Comment addComment(String entityType, UUID entityId, String body) {
+		String username = requireUsername();
+		return commentRepository.save(Comment.create(entityType, entityId, username, body));
+	}
+
+	@Transactional
+	public void deleteComment(UUID id) {
+		String username = requireUsername();
+		Comment comment = commentRepository.findById(id)
+			.orElseThrow(() -> new CommentNotFoundException(id));
+		if (!comment.getUsername().equals(username)) {
+			throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only the author can delete this comment");
+		}
+		commentRepository.delete(comment);
+	}
+
+	@Transactional(readOnly = true)
+	public List<Comment> getMyComments() {
+		String username = currentUsername();
+		if (username == null) return List.of();
+		return commentRepository.findByUsername(username);
+	}
+
+	private String requireUsername() {
+		String username = currentUsername();
+		if (username == null) throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authentication required");
+		return username;
+	}
+
+	private static String currentUsername() {
+		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+		if (auth instanceof JwtAuthenticationToken jwtAuth) {
+			return jwtAuth.getToken().getClaimAsString("preferred_username");
+		}
+		return null;
+	}
+}

--- a/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/application/LikeService.java
+++ b/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/application/LikeService.java
@@ -1,0 +1,70 @@
+package com.yaseminyumak.culinarygraphbackend.social.application;
+
+import com.yaseminyumak.culinarygraphbackend.social.domain.Like;
+import com.yaseminyumak.culinarygraphbackend.social.domain.LikeRepository;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class LikeService {
+
+	private final LikeRepository likeRepository;
+
+	public LikeService(LikeRepository likeRepository) {
+		this.likeRepository = likeRepository;
+	}
+
+	@Transactional
+	public LikeStatus toggle(String entityType, UUID entityId) {
+		String username = requireUsername();
+		Optional<Like> existing = likeRepository.findByEntityTypeAndEntityIdAndUsername(entityType, entityId, username);
+		if (existing.isPresent()) {
+			likeRepository.delete(existing.get());
+		} else {
+			likeRepository.save(Like.create(entityType, entityId, username));
+		}
+		long count = likeRepository.countByEntityTypeAndEntityId(entityType, entityId);
+		boolean likedByMe = existing.isEmpty();
+		return new LikeStatus(count, likedByMe);
+	}
+
+	@Transactional(readOnly = true)
+	public LikeStatus getStatus(String entityType, UUID entityId) {
+		long count = likeRepository.countByEntityTypeAndEntityId(entityType, entityId);
+		String username = currentUsername();
+		boolean likedByMe = username != null &&
+			likeRepository.findByEntityTypeAndEntityIdAndUsername(entityType, entityId, username).isPresent();
+		return new LikeStatus(count, likedByMe);
+	}
+
+	@Transactional(readOnly = true)
+	public List<Like> getMyLikes() {
+		String username = currentUsername();
+		if (username == null) return List.of();
+		return likeRepository.findByUsername(username);
+	}
+
+	public record LikeStatus(long count, boolean likedByMe) {}
+
+	private String requireUsername() {
+		String username = currentUsername();
+		if (username == null) throw new org.springframework.web.server.ResponseStatusException(
+			org.springframework.http.HttpStatus.UNAUTHORIZED, "Authentication required");
+		return username;
+	}
+
+	private static String currentUsername() {
+		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+		if (auth instanceof JwtAuthenticationToken jwtAuth) {
+			return jwtAuth.getToken().getClaimAsString("preferred_username");
+		}
+		return null;
+	}
+}

--- a/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/domain/Comment.java
+++ b/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/domain/Comment.java
@@ -1,0 +1,37 @@
+package com.yaseminyumak.culinarygraphbackend.social.domain;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public class Comment {
+	private final UUID id;
+	private final String entityType;
+	private final UUID entityId;
+	private final String username;
+	private final String body;
+	private final Instant createdAt;
+
+	private Comment(UUID id, String entityType, UUID entityId, String username, String body, Instant createdAt) {
+		this.id = id;
+		this.entityType = entityType;
+		this.entityId = entityId;
+		this.username = username;
+		this.body = body;
+		this.createdAt = createdAt;
+	}
+
+	public static Comment create(String entityType, UUID entityId, String username, String body) {
+		return new Comment(UUID.randomUUID(), entityType, entityId, username, body, Instant.now());
+	}
+
+	public static Comment fromPersistence(UUID id, String entityType, UUID entityId, String username, String body, Instant createdAt) {
+		return new Comment(id, entityType, entityId, username, body, createdAt);
+	}
+
+	public UUID getId() { return id; }
+	public String getEntityType() { return entityType; }
+	public UUID getEntityId() { return entityId; }
+	public String getUsername() { return username; }
+	public String getBody() { return body; }
+	public Instant getCreatedAt() { return createdAt; }
+}

--- a/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/domain/CommentNotFoundException.java
+++ b/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/domain/CommentNotFoundException.java
@@ -1,0 +1,9 @@
+package com.yaseminyumak.culinarygraphbackend.social.domain;
+
+import java.util.UUID;
+
+public class CommentNotFoundException extends RuntimeException {
+	public CommentNotFoundException(UUID id) {
+		super("Comment not found: " + id);
+	}
+}

--- a/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/domain/CommentRepository.java
+++ b/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/domain/CommentRepository.java
@@ -1,0 +1,13 @@
+package com.yaseminyumak.culinarygraphbackend.social.domain;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface CommentRepository {
+	Comment save(Comment comment);
+	Optional<Comment> findById(UUID id);
+	List<Comment> findByEntityTypeAndEntityId(String entityType, UUID entityId);
+	List<Comment> findByUsername(String username);
+	void delete(Comment comment);
+}

--- a/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/domain/Like.java
+++ b/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/domain/Like.java
@@ -1,0 +1,34 @@
+package com.yaseminyumak.culinarygraphbackend.social.domain;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public class Like {
+	private final UUID id;
+	private final String entityType;
+	private final UUID entityId;
+	private final String username;
+	private final Instant createdAt;
+
+	private Like(UUID id, String entityType, UUID entityId, String username, Instant createdAt) {
+		this.id = id;
+		this.entityType = entityType;
+		this.entityId = entityId;
+		this.username = username;
+		this.createdAt = createdAt;
+	}
+
+	public static Like create(String entityType, UUID entityId, String username) {
+		return new Like(UUID.randomUUID(), entityType, entityId, username, Instant.now());
+	}
+
+	public static Like fromPersistence(UUID id, String entityType, UUID entityId, String username, Instant createdAt) {
+		return new Like(id, entityType, entityId, username, createdAt);
+	}
+
+	public UUID getId() { return id; }
+	public String getEntityType() { return entityType; }
+	public UUID getEntityId() { return entityId; }
+	public String getUsername() { return username; }
+	public Instant getCreatedAt() { return createdAt; }
+}

--- a/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/domain/LikeRepository.java
+++ b/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/domain/LikeRepository.java
@@ -1,0 +1,13 @@
+package com.yaseminyumak.culinarygraphbackend.social.domain;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface LikeRepository {
+	Like save(Like like);
+	Optional<Like> findByEntityTypeAndEntityIdAndUsername(String entityType, UUID entityId, String username);
+	long countByEntityTypeAndEntityId(String entityType, UUID entityId);
+	List<Like> findByUsername(String username);
+	void delete(Like like);
+}

--- a/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/infrastructure/CommentEntity.java
+++ b/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/infrastructure/CommentEntity.java
@@ -1,0 +1,45 @@
+package com.yaseminyumak.culinarygraphbackend.social.infrastructure;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "social_comments")
+public class CommentEntity {
+
+	@Id
+	@Column(name = "id")
+	private UUID id;
+
+	@Column(name = "entity_type", nullable = false, length = 20)
+	private String entityType;
+
+	@Column(name = "entity_id", nullable = false)
+	private UUID entityId;
+
+	@Column(name = "username", nullable = false)
+	private String username;
+
+	@Column(name = "body", nullable = false, columnDefinition = "TEXT")
+	private String body;
+
+	@Column(name = "created_at", nullable = false)
+	private Instant createdAt;
+
+	@SuppressWarnings("unused")
+	protected CommentEntity() {}
+
+	public UUID getId() { return id; }
+	public void setId(UUID id) { this.id = id; }
+	public String getEntityType() { return entityType; }
+	public void setEntityType(String entityType) { this.entityType = entityType; }
+	public UUID getEntityId() { return entityId; }
+	public void setEntityId(UUID entityId) { this.entityId = entityId; }
+	public String getUsername() { return username; }
+	public void setUsername(String username) { this.username = username; }
+	public String getBody() { return body; }
+	public void setBody(String body) { this.body = body; }
+	public Instant getCreatedAt() { return createdAt; }
+	public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+}

--- a/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/infrastructure/CommentJpaRepository.java
+++ b/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/infrastructure/CommentJpaRepository.java
@@ -1,0 +1,10 @@
+package com.yaseminyumak.culinarygraphbackend.social.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+import java.util.UUID;
+
+public interface CommentJpaRepository extends JpaRepository<CommentEntity, UUID> {
+	List<CommentEntity> findByEntityTypeAndEntityIdOrderByCreatedAtAsc(String entityType, UUID entityId);
+	List<CommentEntity> findByUsernameOrderByCreatedAtDesc(String username);
+}

--- a/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/infrastructure/CommentRepositoryImpl.java
+++ b/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/infrastructure/CommentRepositoryImpl.java
@@ -1,0 +1,62 @@
+package com.yaseminyumak.culinarygraphbackend.social.infrastructure;
+
+import com.yaseminyumak.culinarygraphbackend.social.domain.Comment;
+import com.yaseminyumak.culinarygraphbackend.social.domain.CommentRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Component
+public class CommentRepositoryImpl implements CommentRepository {
+
+	private final CommentJpaRepository jpa;
+
+	public CommentRepositoryImpl(CommentJpaRepository jpa) {
+		this.jpa = jpa;
+	}
+
+	@Override
+	public Comment save(Comment comment) {
+		return toDomain(jpa.save(toEntity(comment)));
+	}
+
+	@Override
+	public Optional<Comment> findById(UUID id) {
+		return jpa.findById(id).map(this::toDomain);
+	}
+
+	@Override
+	public List<Comment> findByEntityTypeAndEntityId(String entityType, UUID entityId) {
+		return jpa.findByEntityTypeAndEntityIdOrderByCreatedAtAsc(entityType, entityId)
+			.stream().map(this::toDomain).collect(Collectors.toList());
+	}
+
+	@Override
+	public List<Comment> findByUsername(String username) {
+		return jpa.findByUsernameOrderByCreatedAtDesc(username)
+			.stream().map(this::toDomain).collect(Collectors.toList());
+	}
+
+	@Override
+	public void delete(Comment comment) {
+		jpa.deleteById(comment.getId());
+	}
+
+	private CommentEntity toEntity(Comment c) {
+		CommentEntity e = new CommentEntity();
+		e.setId(c.getId());
+		e.setEntityType(c.getEntityType());
+		e.setEntityId(c.getEntityId());
+		e.setUsername(c.getUsername());
+		e.setBody(c.getBody());
+		e.setCreatedAt(c.getCreatedAt());
+		return e;
+	}
+
+	private Comment toDomain(CommentEntity e) {
+		return Comment.fromPersistence(e.getId(), e.getEntityType(), e.getEntityId(), e.getUsername(), e.getBody(), e.getCreatedAt());
+	}
+}

--- a/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/infrastructure/LikeEntity.java
+++ b/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/infrastructure/LikeEntity.java
@@ -1,0 +1,40 @@
+package com.yaseminyumak.culinarygraphbackend.social.infrastructure;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "social_likes")
+public class LikeEntity {
+
+	@Id
+	@Column(name = "id")
+	private UUID id;
+
+	@Column(name = "entity_type", nullable = false, length = 20)
+	private String entityType;
+
+	@Column(name = "entity_id", nullable = false)
+	private UUID entityId;
+
+	@Column(name = "username", nullable = false)
+	private String username;
+
+	@Column(name = "created_at", nullable = false)
+	private Instant createdAt;
+
+	@SuppressWarnings("unused")
+	protected LikeEntity() {}
+
+	public UUID getId() { return id; }
+	public void setId(UUID id) { this.id = id; }
+	public String getEntityType() { return entityType; }
+	public void setEntityType(String entityType) { this.entityType = entityType; }
+	public UUID getEntityId() { return entityId; }
+	public void setEntityId(UUID entityId) { this.entityId = entityId; }
+	public String getUsername() { return username; }
+	public void setUsername(String username) { this.username = username; }
+	public Instant getCreatedAt() { return createdAt; }
+	public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+}

--- a/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/infrastructure/LikeJpaRepository.java
+++ b/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/infrastructure/LikeJpaRepository.java
@@ -1,0 +1,12 @@
+package com.yaseminyumak.culinarygraphbackend.social.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface LikeJpaRepository extends JpaRepository<LikeEntity, UUID> {
+	Optional<LikeEntity> findByEntityTypeAndEntityIdAndUsername(String entityType, UUID entityId, String username);
+	long countByEntityTypeAndEntityId(String entityType, UUID entityId);
+	List<LikeEntity> findByUsername(String username);
+}

--- a/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/infrastructure/LikeRepositoryImpl.java
+++ b/culinarygraph-backend/src/main/java/com/yaseminyumak/culinarygraphbackend/social/infrastructure/LikeRepositoryImpl.java
@@ -1,0 +1,60 @@
+package com.yaseminyumak.culinarygraphbackend.social.infrastructure;
+
+import com.yaseminyumak.culinarygraphbackend.social.domain.Like;
+import com.yaseminyumak.culinarygraphbackend.social.domain.LikeRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Component
+public class LikeRepositoryImpl implements LikeRepository {
+
+	private final LikeJpaRepository jpa;
+
+	public LikeRepositoryImpl(LikeJpaRepository jpa) {
+		this.jpa = jpa;
+	}
+
+	@Override
+	public Like save(Like like) {
+		LikeEntity e = toEntity(like);
+		return toDomain(jpa.save(e));
+	}
+
+	@Override
+	public Optional<Like> findByEntityTypeAndEntityIdAndUsername(String entityType, UUID entityId, String username) {
+		return jpa.findByEntityTypeAndEntityIdAndUsername(entityType, entityId, username).map(this::toDomain);
+	}
+
+	@Override
+	public long countByEntityTypeAndEntityId(String entityType, UUID entityId) {
+		return jpa.countByEntityTypeAndEntityId(entityType, entityId);
+	}
+
+	@Override
+	public List<Like> findByUsername(String username) {
+		return jpa.findByUsername(username).stream().map(this::toDomain).collect(Collectors.toList());
+	}
+
+	@Override
+	public void delete(Like like) {
+		jpa.deleteById(like.getId());
+	}
+
+	private LikeEntity toEntity(Like like) {
+		LikeEntity e = new LikeEntity();
+		e.setId(like.getId());
+		e.setEntityType(like.getEntityType());
+		e.setEntityId(like.getEntityId());
+		e.setUsername(like.getUsername());
+		e.setCreatedAt(like.getCreatedAt());
+		return e;
+	}
+
+	private Like toDomain(LikeEntity e) {
+		return Like.fromPersistence(e.getId(), e.getEntityType(), e.getEntityId(), e.getUsername(), e.getCreatedAt());
+	}
+}

--- a/culinarygraph-backend/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/culinarygraph-backend/src/main/resources/db/changelog/db.changelog-master.xml
@@ -11,4 +11,5 @@
     <include file="v1.3.0-add-extended-fields.sql" relativeToChangelogFile="true"/>
     <include file="v1.4.0-add-images.sql" relativeToChangelogFile="true"/>
     <include file="v1.5.0-id-based-relations.sql" relativeToChangelogFile="true"/>
+    <include file="v1.6.0-social.sql" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/culinarygraph-backend/src/main/resources/db/changelog/v1.6.0-social.sql
+++ b/culinarygraph-backend/src/main/resources/db/changelog/v1.6.0-social.sql
@@ -1,0 +1,24 @@
+--liquibase formatted sql
+
+--changeset culinarygraph:7
+
+CREATE TABLE social_likes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    entity_type VARCHAR(20) NOT NULL,
+    entity_id UUID NOT NULL,
+    username VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_like UNIQUE(entity_type, entity_id, username)
+);
+
+CREATE TABLE social_comments (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    entity_type VARCHAR(20) NOT NULL,
+    entity_id UUID NOT NULL,
+    username VARCHAR(255) NOT NULL,
+    body TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_likes_entity ON social_likes(entity_type, entity_id);
+CREATE INDEX idx_comments_entity ON social_comments(entity_type, entity_id);

--- a/culinarygraph-frontend/src/features/catalog/HomePage.tsx
+++ b/culinarygraph-frontend/src/features/catalog/HomePage.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from 'react'
 import { fetchIngredients, fetchTechniques } from './catalogApi'
 import { fetchRecipes } from '../recipe/recipeApi'
 import EntityCardImage from '../../shared/components/EntityCardImage'
+import SocialCounts from '../social/SocialCounts'
 
 type ItemType = 'recipe' | 'ingredient' | 'technique'
 interface CardItem { type: ItemType; id: string; name: string; desc: string; location: string }
@@ -83,6 +84,7 @@ export default function HomePage() {
                 <div className="p-3">
                   <p className="font-bold text-sm text-[#171433] group-hover:text-[#8c2d9c] truncate leading-snug">{item.name}</p>
                   {item.location && <p className="text-xs text-[#8c2d9c] mt-1 font-medium truncate">{item.location}</p>}
+                  <SocialCounts entityType={entityType(item.type)} entityId={item.id} />
                 </div>
               </Link>
             ))}
@@ -104,6 +106,7 @@ export default function HomePage() {
                 <div className="p-3">
                   <p className="font-bold text-sm text-[#171433] group-hover:text-[#8c2d9c] truncate leading-snug">{item.name}</p>
                   {item.location && <p className="text-xs text-[#8c2d9c] mt-1 truncate font-medium">{item.location}</p>}
+                  <SocialCounts entityType={entityType(item.type)} entityId={item.id} />
                 </div>
               </Link>
             ))}

--- a/culinarygraph-frontend/src/features/catalog/IngredientDetailPage.tsx
+++ b/culinarygraph-frontend/src/features/catalog/IngredientDetailPage.tsx
@@ -6,6 +6,8 @@ import ImageManager from '../../shared/components/ImageManager'
 import ConfirmModal from '../../shared/components/ConfirmModal'
 import { useCatalogIndex } from '../../shared/hooks/useCatalogIndex'
 import { useAuth } from '../../auth/AuthProvider'
+import LikeButton from '../social/LikeButton'
+import CommentSection from '../social/CommentSection'
 
 export default function IngredientDetailPage() {
   const { id } = useParams<{ id: string }>()
@@ -13,6 +15,7 @@ export default function IngredientDetailPage() {
   const { isAuthenticated, keycloak } = useAuth()
   const queryClient = useQueryClient()
   const [showConfirm, setShowConfirm] = useState(false)
+  const [commentCount, setCommentCount] = useState(0)
   const { techniqueById } = useCatalogIndex()
 
   const { data: ingredient, isLoading, error } = useQuery({
@@ -125,6 +128,12 @@ export default function IngredientDetailPage() {
             </ul>
           </div>
         )}
+
+        <div className="pt-4 border-t border-gray-100">
+          <LikeButton entityType="INGREDIENT" entityId={ingredient.id} commentCount={commentCount} />
+        </div>
+
+        <CommentSection entityType="INGREDIENT" entityId={ingredient.id} onCommentCountChange={setCommentCount} />
 
         {ingredient.createdBy && (
           <div className="pt-4 border-t border-gray-100">

--- a/culinarygraph-frontend/src/features/catalog/TechniqueDetailPage.tsx
+++ b/culinarygraph-frontend/src/features/catalog/TechniqueDetailPage.tsx
@@ -6,6 +6,8 @@ import ImageManager from '../../shared/components/ImageManager'
 import ConfirmModal from '../../shared/components/ConfirmModal'
 import { useCatalogIndex } from '../../shared/hooks/useCatalogIndex'
 import { useAuth } from '../../auth/AuthProvider'
+import LikeButton from '../social/LikeButton'
+import CommentSection from '../social/CommentSection'
 
 export default function TechniqueDetailPage() {
   const { id } = useParams<{ id: string }>()
@@ -13,6 +15,7 @@ export default function TechniqueDetailPage() {
   const { isAuthenticated, keycloak } = useAuth()
   const queryClient = useQueryClient()
   const [showConfirm, setShowConfirm] = useState(false)
+  const [commentCount, setCommentCount] = useState(0)
   const { ingredientById, techniqueById } = useCatalogIndex()
 
   const { data: technique, isLoading, error } = useQuery({
@@ -143,6 +146,12 @@ export default function TechniqueDetailPage() {
             </ul>
           </div>
         )}
+
+        <div className="pt-4 border-t border-gray-100">
+          <LikeButton entityType="TECHNIQUE" entityId={technique.id} commentCount={commentCount} />
+        </div>
+
+        <CommentSection entityType="TECHNIQUE" entityId={technique.id} onCommentCountChange={setCommentCount} />
 
         {technique.createdBy && (
           <div className="pt-4 border-t border-gray-100">

--- a/culinarygraph-frontend/src/features/profile/ProfilePage.tsx
+++ b/culinarygraph-frontend/src/features/profile/ProfilePage.tsx
@@ -1,10 +1,11 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, Link } from 'react-router-dom'
 import { useAuth } from '../../auth/AuthProvider'
 import { fetchIngredients, fetchTechniques, deleteIngredient, deleteTechnique } from '../catalog/catalogApi'
 import { fetchRecipes, deleteRecipe } from '../recipe/recipeApi'
 import ConfirmModal from '../../shared/components/ConfirmModal'
+import { fetchMyLikes, fetchMyComments } from '../social/socialApi'
 
 export default function ProfilePage() {
   const { keycloak, isAuthenticated } = useAuth()
@@ -12,13 +13,14 @@ export default function ProfilePage() {
   const queryClient = useQueryClient()
   const [confirmState, setConfirmState] = useState<{ label: string; onConfirm: () => void } | null>(null)
 
-  const userId = keycloak.subject
   const username = keycloak.tokenParsed?.preferred_username ?? keycloak.tokenParsed?.sub ?? 'User'
   const email = keycloak.tokenParsed?.email ?? ''
 
   const { data: ingredients } = useQuery({ queryKey: ['catalog', 'ingredients'], queryFn: fetchIngredients })
   const { data: techniques } = useQuery({ queryKey: ['catalog', 'techniques'], queryFn: fetchTechniques })
   const { data: recipes } = useQuery({ queryKey: ['recipes'], queryFn: fetchRecipes })
+  const { data: myLikes = [] } = useQuery({ queryKey: ['likes', 'mine'], queryFn: fetchMyLikes })
+  const { data: myComments = [] } = useQuery({ queryKey: ['comments', 'mine'], queryFn: fetchMyComments })
 
   const delIngredient = useMutation({
     mutationFn: (id: string) => deleteIngredient(id),
@@ -45,9 +47,22 @@ export default function ProfilePage() {
     )
   }
 
-  const myTechniques = techniques?.filter((t) => t.createdBy === userId) ?? []
-  const myIngredients = ingredients?.filter((i) => i.createdBy === userId) ?? []
-  const myRecipes = recipes?.filter((r) => r.createdBy === userId) ?? []
+  const myTechniques = techniques?.filter((t) => t.createdBy === username) ?? []
+  const myIngredients = ingredients?.filter((i) => i.createdBy === username) ?? []
+  const myRecipes = recipes?.filter((r) => r.createdBy === username) ?? []
+
+  const likedRecipes = myLikes
+    .filter((l) => l.entityType === 'RECIPE')
+    .map((l) => recipes?.find((r) => r.id === l.entityId))
+    .filter(Boolean)
+  const likedIngredients = myLikes
+    .filter((l) => l.entityType === 'INGREDIENT')
+    .map((l) => ingredients?.find((i) => i.id === l.entityId))
+    .filter(Boolean)
+  const likedTechniques = myLikes
+    .filter((l) => l.entityType === 'TECHNIQUE')
+    .map((l) => techniques?.find((t) => t.id === l.entityId))
+    .filter(Boolean)
 
   return (
     <>
@@ -123,6 +138,61 @@ export default function ProfilePage() {
               </div>
             ))}
           </div>
+        )}
+      </section>
+
+      {/* My Activity */}
+      <section className="mb-8">
+        <h2 className="font-bold text-base text-[#171433] mb-3">My Activity</h2>
+
+        {(likedRecipes.length > 0 || likedIngredients.length > 0 || likedTechniques.length > 0) && (
+          <div className="mb-4">
+            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Liked Content</p>
+            <div className="border border-gray-200 rounded-lg divide-y divide-gray-100 bg-white shadow-sm overflow-hidden">
+              {likedRecipes.map((r) => r && (
+                <Link key={r.id} to={`/recipes/${r.id}`}
+                  className="flex items-center gap-2 px-4 py-2.5 hover:bg-[#ede8ee] transition-colors">
+                  <span className="text-xs bg-[#ede8ee] text-[#8c2d9c] px-2 py-0.5 rounded font-medium flex-shrink-0">Recipe</span>
+                  <span className="text-sm text-gray-700 truncate">{r.title}</span>
+                </Link>
+              ))}
+              {likedIngredients.map((i) => i && (
+                <Link key={i.id} to={`/catalog/ingredients/${i.id}`}
+                  className="flex items-center gap-2 px-4 py-2.5 hover:bg-[#ede8ee] transition-colors">
+                  <span className="text-xs bg-[#ede8ee] text-[#8c2d9c] px-2 py-0.5 rounded font-medium flex-shrink-0">Ingredient</span>
+                  <span className="text-sm text-gray-700 truncate">{i.name}</span>
+                </Link>
+              ))}
+              {likedTechniques.map((t) => t && (
+                <Link key={t.id} to={`/catalog/techniques/${t.id}`}
+                  className="flex items-center gap-2 px-4 py-2.5 hover:bg-[#ede8ee] transition-colors">
+                  <span className="text-xs bg-[#ede8ee] text-[#8c2d9c] px-2 py-0.5 rounded font-medium flex-shrink-0">Technique</span>
+                  <span className="text-sm text-gray-700 truncate">{t.name}</span>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {myComments.length > 0 && (
+          <div>
+            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Recent Comments</p>
+            <div className="border border-gray-200 rounded-lg divide-y divide-gray-100 bg-white shadow-sm overflow-hidden">
+              {myComments.slice(0, 5).map((c) => (
+                <div key={c.id} className="px-4 py-2.5">
+                  <div className="flex items-center gap-2 mb-0.5">
+                    <span className="text-xs bg-[#ede8ee] text-[#8c2d9c] px-2 py-0.5 rounded font-medium">{c.username}</span>
+                    <span className="text-xs text-gray-400">{new Date(c.createdAt).toLocaleDateString()}</span>
+                  </div>
+                  <p className="text-sm text-gray-700 line-clamp-1">{c.body}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {likedRecipes.length === 0 && likedIngredients.length === 0 && likedTechniques.length === 0 && myComments.length === 0 && (
+          <p className="text-sm text-gray-400">No activity yet.</p>
         )}
       </section>
 

--- a/culinarygraph-frontend/src/features/recipe/RecipeDetailPage.tsx
+++ b/culinarygraph-frontend/src/features/recipe/RecipeDetailPage.tsx
@@ -6,6 +6,8 @@ import { useCatalogIndex } from '../../shared/hooks/useCatalogIndex'
 import ImageManager from '../../shared/components/ImageManager'
 import ConfirmModal from '../../shared/components/ConfirmModal'
 import { useAuth } from '../../auth/AuthProvider'
+import LikeButton from '../social/LikeButton'
+import CommentSection from '../social/CommentSection'
 
 export default function RecipeDetailPage() {
   const { id } = useParams<{ id: string }>()
@@ -13,6 +15,7 @@ export default function RecipeDetailPage() {
   const { isAuthenticated, keycloak } = useAuth()
   const queryClient = useQueryClient()
   const [showConfirm, setShowConfirm] = useState(false)
+  const [commentCount, setCommentCount] = useState(0)
   const { data: recipe, isLoading, error } = useQuery({
     queryKey: ['recipes', id],
     queryFn: () => fetchRecipe(id!),
@@ -147,6 +150,12 @@ export default function RecipeDetailPage() {
             </p>
           </div>
         )}
+
+        <div className="pt-4 border-t border-gray-100">
+          <LikeButton entityType="RECIPE" entityId={recipe.id} commentCount={commentCount} />
+        </div>
+
+        <CommentSection entityType="RECIPE" entityId={recipe.id} onCommentCountChange={setCommentCount} />
 
         {recipe.createdBy && (
           <div className="pt-4 border-t border-gray-100">

--- a/culinarygraph-frontend/src/features/social/CommentSection.tsx
+++ b/culinarygraph-frontend/src/features/social/CommentSection.tsx
@@ -1,0 +1,107 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
+import { useAuth } from '../../auth/AuthProvider'
+import { fetchComments, addComment, deleteComment } from './socialApi'
+
+interface Props {
+  entityType: string
+  entityId: string
+  onCommentCountChange?: (count: number) => void
+}
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime()
+  const minutes = Math.floor(diff / 60000)
+  if (minutes < 1) return 'just now'
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 7) return `${days}d ago`
+  return new Date(iso).toLocaleDateString()
+}
+
+export default function CommentSection({ entityType, entityId, onCommentCountChange }: Props) {
+  const { isAuthenticated, keycloak } = useAuth()
+  const queryClient = useQueryClient()
+  const [body, setBody] = useState('')
+
+  const { data: comments = [] } = useQuery({
+    queryKey: ['comments', entityType, entityId],
+    queryFn: () => fetchComments(entityType, entityId),
+    select: (data) => {
+      onCommentCountChange?.(data.length)
+      return data
+    },
+  })
+
+  const addMutation = useMutation({
+    mutationFn: () => addComment(entityType, entityId, body.trim()),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['comments', entityType, entityId] })
+      setBody('')
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteComment(id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['comments', entityType, entityId] }),
+  })
+
+  const currentUsername = keycloak.tokenParsed?.preferred_username
+
+  return (
+    <div className="mt-8 border-t border-gray-100 pt-6">
+      <h2 className="text-base font-bold text-[#171433] mb-4">Comments</h2>
+
+      {comments.length > 0 ? (
+        <div className="border border-gray-200 rounded-xl divide-y divide-gray-100 bg-white shadow-sm mb-6">
+          {comments.map((c) => (
+            <div key={c.id} className="px-4 py-3">
+              <div className="flex items-center justify-between gap-2 mb-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-bold text-[#171433]">{c.username}</span>
+                  <span className="text-xs text-gray-400">{timeAgo(c.createdAt)}</span>
+                </div>
+                {isAuthenticated && c.username === currentUsername && (
+                  <button
+                    onClick={() => deleteMutation.mutate(c.id)}
+                    disabled={deleteMutation.isPending}
+                    className="text-xs text-gray-400 hover:text-red-500 transition-colors disabled:opacity-50"
+                  >
+                    Delete
+                  </button>
+                )}
+              </div>
+              <p className="text-sm text-gray-700 leading-relaxed">{c.body}</p>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-gray-400 mb-6">No comments yet.</p>
+      )}
+
+      {isAuthenticated ? (
+        <div className="border border-gray-200 rounded-xl bg-white p-4 shadow-sm">
+          <p className="text-sm font-medium text-[#171433] mb-2">Add a Comment</p>
+          <textarea
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            rows={3}
+            placeholder="Write your comment..."
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm resize-none focus:outline-none focus:border-[#8c2d9c]"
+          />
+          <button
+            onClick={() => { if (body.trim()) addMutation.mutate() }}
+            disabled={!body.trim() || addMutation.isPending}
+            className="mt-2 px-4 py-1.5 text-sm font-medium bg-[#8c2d9c] text-white rounded hover:bg-[#7a2589] transition-colors disabled:opacity-50"
+          >
+            Post Comment
+          </button>
+        </div>
+      ) : (
+        <p className="text-sm text-gray-400 italic">Log in to leave a comment.</p>
+      )}
+    </div>
+  )
+}

--- a/culinarygraph-frontend/src/features/social/LikeButton.tsx
+++ b/culinarygraph-frontend/src/features/social/LikeButton.tsx
@@ -1,0 +1,45 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useAuth } from '../../auth/AuthProvider'
+import { fetchLikeStatus, toggleLike } from './socialApi'
+
+interface Props {
+  entityType: string
+  entityId: string
+  commentCount?: number
+}
+
+export default function LikeButton({ entityType, entityId, commentCount }: Props) {
+  const { isAuthenticated } = useAuth()
+  const queryClient = useQueryClient()
+
+  const { data: status } = useQuery({
+    queryKey: ['likes', entityType, entityId],
+    queryFn: () => fetchLikeStatus(entityType, entityId),
+  })
+
+  const mutation = useMutation({
+    mutationFn: () => toggleLike(entityType, entityId),
+    onSuccess: (data) => queryClient.setQueryData(['likes', entityType, entityId], data),
+  })
+
+  return (
+    <div className="flex items-center gap-4">
+      <button
+        onClick={() => { if (isAuthenticated) mutation.mutate() }}
+        disabled={!isAuthenticated || mutation.isPending}
+        title={isAuthenticated ? undefined : 'Log in to like'}
+        className={`flex items-center gap-1.5 px-3 py-1.5 text-sm border rounded transition-colors ${
+          status?.likedByMe
+            ? 'bg-[#8c2d9c] text-white border-[#8c2d9c]'
+            : 'border-gray-300 text-gray-600 hover:border-[#8c2d9c] hover:text-[#8c2d9c]'
+        } disabled:opacity-50 disabled:cursor-default`}
+      >
+        ♥ Like
+      </button>
+      <span className="text-sm text-gray-500">{status?.count ?? 0} {(status?.count ?? 0) === 1 ? 'Like' : 'Likes'}</span>
+      {commentCount !== undefined && (
+        <span className="text-sm text-gray-500">{commentCount} {commentCount === 1 ? 'Comment' : 'Comments'}</span>
+      )}
+    </div>
+  )
+}

--- a/culinarygraph-frontend/src/features/social/SocialCounts.tsx
+++ b/culinarygraph-frontend/src/features/social/SocialCounts.tsx
@@ -1,0 +1,34 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchLikeStatus, fetchComments } from './socialApi'
+
+interface Props {
+  entityType: string
+  entityId: string
+}
+
+export default function SocialCounts({ entityType, entityId }: Props) {
+  const { data: likes } = useQuery({
+    queryKey: ['likes', entityType, entityId],
+    queryFn: () => fetchLikeStatus(entityType, entityId),
+  })
+  const { data: comments } = useQuery({
+    queryKey: ['comments', entityType, entityId],
+    queryFn: () => fetchComments(entityType, entityId),
+  })
+
+  const likeCount = likes?.count ?? 0
+  const commentCount = comments?.length ?? 0
+
+  if (likeCount === 0 && commentCount === 0) return null
+
+  return (
+    <div className="flex items-center gap-3 mt-1">
+      {likeCount > 0 && (
+        <span className="text-xs text-gray-400">♥ {likeCount}</span>
+      )}
+      {commentCount > 0 && (
+        <span className="text-xs text-gray-400">💬 {commentCount}</span>
+      )}
+    </div>
+  )
+}

--- a/culinarygraph-frontend/src/features/social/socialApi.ts
+++ b/culinarygraph-frontend/src/features/social/socialApi.ts
@@ -1,0 +1,45 @@
+import { apiClient } from '../../shared/api/client'
+
+export interface LikeStatus {
+  count: number
+  likedByMe: boolean
+}
+
+export interface CommentDto {
+  id: string
+  username: string
+  body: string
+  createdAt: string
+}
+
+export interface LikedEntity {
+  entityType: string
+  entityId: string
+}
+
+export const fetchLikeStatus = (entityType: string, entityId: string) =>
+  apiClient<LikeStatus>(`/social/likes?entityType=${entityType}&entityId=${entityId}`)
+
+export const toggleLike = (entityType: string, entityId: string) =>
+  apiClient<LikeStatus>('/social/likes', {
+    method: 'POST',
+    body: JSON.stringify({ entityType, entityId }),
+  })
+
+export const fetchComments = (entityType: string, entityId: string) =>
+  apiClient<CommentDto[]>(`/social/comments?entityType=${entityType}&entityId=${entityId}`)
+
+export const addComment = (entityType: string, entityId: string, body: string) =>
+  apiClient<CommentDto>('/social/comments', {
+    method: 'POST',
+    body: JSON.stringify({ entityType, entityId, body }),
+  })
+
+export const deleteComment = (commentId: string) =>
+  apiClient<void>(`/social/comments/${commentId}`, { method: 'DELETE' })
+
+export const fetchMyLikes = () =>
+  apiClient<LikedEntity[]>('/social/likes/mine')
+
+export const fetchMyComments = () =>
+  apiClient<CommentDto[]>('/social/comments/mine')


### PR DESCRIPTION
Introduces a social bounded context with full DDD stack (domain,                                                                 
  infrastructure, application, API). Users can like/unlike content and                                                             
  post or delete their own comments. Detail pages show a like button with                                                          
  counts and a comment section. Homepage cards show compact like/comment                                                           
  counts. Profile page gains a My Activity section listing liked content                                                           
  and recent comments. Also fixes the profile page createdBy filter that                                                           
  was comparing a username against a Keycloak UUID.

Closes #39 