### PR TITLE
feat: add interactive world food map and expand search

### DIFF
--- a/culinarygraph-frontend/.npmrc
+++ b/culinarygraph-frontend/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/culinarygraph-frontend/Dockerfile
+++ b/culinarygraph-frontend/Dockerfile
@@ -7,7 +7,7 @@ ARG VITE_API_BASE=/api
 ENV VITE_KEYCLOAK_URL=$VITE_KEYCLOAK_URL
 ENV VITE_API_BASE=$VITE_API_BASE
 
-COPY package.json package-lock.json* ./
+COPY package.json package-lock.json* .npmrc* ./
 RUN npm config set strict-ssl false && npm ci
 COPY . .
 RUN npm run build

--- a/culinarygraph-frontend/package-lock.json
+++ b/culinarygraph-frontend/package-lock.json
@@ -10,9 +10,11 @@
       "dependencies": {
         "@tanstack/react-query": "^5.90.21",
         "keycloak-js": "^26.2.3",
+        "prop-types": "^15.8.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
-        "react-router-dom": "^7.13.1"
+        "react-router-dom": "^7.13.1",
+        "react-simple-maps": "^3.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -28,7 +30,6 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
-        "happy-dom": "^20.9.0",
         "jsdom": "^29.1.1",
         "tailwindcss": "^4.2.1",
         "typescript": "~5.9.3",
@@ -1921,27 +1922,6 @@
         "react": "^18 || ^19"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -2010,14 +1990,6 @@
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
       }
-    },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2124,23 +2096,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
-      }
-    },
-    "node_modules/@types/whatwg-mimetype": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
-      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2612,17 +2567,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2819,6 +2763,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2889,6 +2839,102 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-dispatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
+      "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-drag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-2.0.0.tgz",
+      "integrity": "sha512-g9y9WbMnF5uqB9qKqwIIa/921RYWzlUDv9Jl1/yONQwxbOfszAWTCm8u7HOTgJgRDXiRZN56cHT9pd24dmXs8w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-dispatch": "1 - 2",
+        "d3-selection": "2"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-2.0.0.tgz",
+      "integrity": "sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-geo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.2.tgz",
+      "integrity": "sha512-8pM1WGMLGFuhq9S+FpPURxic+gKzjluCD/CHTuUF3mXMeiCo0i6R0tO1s4+GArRFde96SLcW/kOFRjoAosPsFA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^2.5.0"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-color": "1 - 2"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
+      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-timer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
+      "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-transition": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-2.0.0.tgz",
+      "integrity": "sha512-42ltAGgJesfQE3u9LuuBHNbGrI/AJjNL2OAUdclE70UE6Vy239GCBEYD38uBPoLeNsOhFStGpPI0BAOV+HMxog==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-color": "1 - 2",
+        "d3-dispatch": "1 - 2",
+        "d3-ease": "1 - 2",
+        "d3-interpolate": "1 - 2",
+        "d3-timer": "1 - 2"
+      },
+      "peerDependencies": {
+        "d3-selection": "2"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-2.0.0.tgz",
+      "integrity": "sha512-fFg7aoaEm9/jf+qfstak0IYpnesZLiMX6GZvXtUSdv8RH2o4E2qeelgdU09eKS6wGuiGMfcnMI0nTIqWzRHGpw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-dispatch": "1 - 2",
+        "d3-drag": "2",
+        "d3-interpolate": "1 - 2",
+        "d3-selection": "2",
+        "d3-transition": "2"
+      }
+    },
     "node_modules/data-urls": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -2954,14 +3000,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.307",
@@ -3421,47 +3459,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/happy-dom": {
-      "version": "20.9.0",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
-      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": ">=20.0.0",
-        "@types/whatwg-mimetype": "^3.0.2",
-        "@types/ws": "^8.18.1",
-        "entities": "^7.0.1",
-        "whatwg-mimetype": "^3.0.0",
-        "ws": "^8.18.3"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/happy-dom/node_modules/entities": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/happy-dom/node_modules/whatwg-mimetype": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3549,6 +3546,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3600,7 +3603,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -4031,6 +4033,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4039,17 +4053,6 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -4131,6 +4134,15 @@
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -4305,34 +4317,15 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
       }
     },
     "node_modules/punycode": {
@@ -4367,12 +4360,10 @@
       }
     },
     "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -4420,6 +4411,23 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-simple-maps": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-simple-maps/-/react-simple-maps-3.0.0.tgz",
+      "integrity": "sha512-vKNFrvpPG8Vyfdjnz5Ne1N56rZlDfHXv5THNXOVZMqbX1rWZA48zQuYT03mx6PAKanqarJu/PDLgshIZAfHHqw==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-geo": "^2.0.2",
+        "d3-selection": "^2.0.0",
+        "d3-zoom": "^2.0.0",
+        "topojson-client": "^3.1.0"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.7.2",
+        "react": "^16.8.0 || 17.x || 18.x",
+        "react-dom": "^16.8.0 || 17.x || 18.x"
       }
     },
     "node_modules/redent": {
@@ -4720,6 +4728,20 @@
       "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
     },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
@@ -5123,28 +5145,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/xml-name-validator": {

--- a/culinarygraph-frontend/package.json
+++ b/culinarygraph-frontend/package.json
@@ -14,9 +14,11 @@
   "dependencies": {
     "@tanstack/react-query": "^5.90.21",
     "keycloak-js": "^26.2.3",
+    "prop-types": "^15.8.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-router-dom": "^7.13.1"
+    "react-router-dom": "^7.13.1",
+    "react-simple-maps": "^3.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/culinarygraph-frontend/src/features/catalog/HomePage.tsx
+++ b/culinarygraph-frontend/src/features/catalog/HomePage.tsx
@@ -1,29 +1,18 @@
 import { useQuery } from '@tanstack/react-query'
 import { Link } from 'react-router-dom'
-import { useState, useMemo } from 'react'
 import { fetchIngredients, fetchTechniques } from './catalogApi'
 import { fetchRecipes } from '../recipe/recipeApi'
 import EntityCardImage from '../../shared/components/EntityCardImage'
 import SocialCounts from '../social/SocialCounts'
+import WorldMapSection from './WorldMapSection'
 
 type ItemType = 'recipe' | 'ingredient' | 'technique'
 interface CardItem { type: ItemType; id: string; name: string; desc: string; location: string }
 
 export default function HomePage() {
-  const [selectedCountry, setSelectedCountry] = useState('')
-
-  const { data: ingredients } = useQuery({ queryKey: ['catalog', 'ingredients'], queryFn: fetchIngredients })
-  const { data: techniques } = useQuery({ queryKey: ['catalog', 'techniques'], queryFn: fetchTechniques })
-  const { data: recipes } = useQuery({ queryKey: ['recipes'], queryFn: fetchRecipes })
-
-  const countries = useMemo(() => {
-    const set = new Set([
-      ...(ingredients?.map((i) => i.country).filter(Boolean) ?? []),
-      ...(techniques?.map((t) => t.country).filter(Boolean) ?? []),
-      ...(recipes?.map((r) => r.country).filter(Boolean) ?? []),
-    ] as string[])
-    return Array.from(set).sort()
-  }, [ingredients, techniques, recipes])
+  const { data: ingredients } = useQuery({ queryKey: ['catalog', 'ingredients'], queryFn: fetchIngredients, staleTime: 0 })
+  const { data: techniques } = useQuery({ queryKey: ['catalog', 'techniques'], queryFn: fetchTechniques, staleTime: 0 })
+  const { data: recipes } = useQuery({ queryKey: ['recipes'], queryFn: fetchRecipes, staleTime: 0 })
 
   const toItem = (type: ItemType, id: string, name: string, desc: string, country?: string | null, region?: string | null) =>
     ({ type, id, name, desc, location: [country, region].filter(Boolean).join(', ') })
@@ -51,24 +40,12 @@ export default function HomePage() {
   return (
     <div className="max-w-5xl mx-auto px-6 py-8 space-y-10">
 
-      {/* Knowledge Map */}
-      <section>
-        <h2 className="text-base font-bold text-[#171433] mb-3">Knowledge Map</h2>
-        <div className="border border-[#d67ec9] rounded-xl bg-white flex items-center justify-center h-48 text-sm text-gray-400">
-          Graph/network visualization placeholder (Nodes: Techniques, Ingredients, Regions)
-        </div>
-        <div className="mt-3 flex items-center gap-3">
-          <label className="text-sm font-medium text-[#171433]">Country Filter:</label>
-          <select
-            value={selectedCountry || 'All Countries'}
-            onChange={(e) => setSelectedCountry(e.target.value === 'All Countries' ? '' : e.target.value)}
-            className="border border-gray-300 rounded px-3 py-1.5 text-sm bg-white focus:outline-none focus:border-[#8c2d9c]"
-          >
-            <option>All Countries</option>
-            {countries.map((c) => <option key={c}>{c}</option>)}
-          </select>
-        </div>
-      </section>
+      {/* World Food Map */}
+      <WorldMapSection
+        recipes={recipes ?? []}
+        ingredients={ingredients ?? []}
+        techniques={techniques ?? []}
+      />
 
       {/* Highlighted Content */}
       <section>

--- a/culinarygraph-frontend/src/features/catalog/WorldMapSection.tsx
+++ b/culinarygraph-frontend/src/features/catalog/WorldMapSection.tsx
@@ -1,0 +1,456 @@
+import { useState, useCallback, useRef } from 'react'
+import { Link } from 'react-router-dom'
+import { ComposableMap, Geographies, Geography, Marker } from 'react-simple-maps'
+import type { IngredientResponse, TechniqueResponse } from './catalogApi'
+import type { RecipeResponse } from '../recipe/recipeApi'
+
+const GEO_URL = 'https://cdn.jsdelivr.net/npm/world-atlas@2.0.2/countries-110m.json'
+
+// All countries from COUNTRIES list — geographic centroids [lon, lat]
+const COUNTRY_COORDS: Record<string, [number, number]> = {
+  'Afghanistan':               [67.7,  33.9],
+  'Albania':                   [20.2,  41.2],
+  'Algeria':                   [2.6,   28.0],
+  'Andorra':                   [1.6,   42.5],
+  'Angola':                    [17.9, -11.2],
+  'Antigua and Barbuda':       [-61.8, 17.1],
+  'Argentina':                 [-63.6,-38.4],
+  'Armenia':                   [45.0,  40.1],
+  'Australia':                 [133.8,-25.3],
+  'Austria':                   [14.6,  47.7],
+  'Azerbaijan':                [47.6,  40.1],
+  'Bahamas':                   [-77.4, 25.0],
+  'Bahrain':                   [50.6,  26.0],
+  'Bangladesh':                [90.4,  23.7],
+  'Barbados':                  [-59.6, 13.2],
+  'Belarus':                   [28.0,  53.7],
+  'Belgium':                   [4.5,   50.5],
+  'Belize':                    [-88.5, 17.2],
+  'Benin':                     [2.3,    9.3],
+  'Bhutan':                    [90.4,  27.5],
+  'Bolivia':                   [-64.9,-16.3],
+  'Bosnia and Herzegovina':    [17.7,  44.0],
+  'Botswana':                  [24.7, -22.3],
+  'Brazil':                    [-51.9,-14.2],
+  'Brunei':                    [114.7,  4.5],
+  'Bulgaria':                  [25.5,  42.8],
+  'Burkina Faso':              [-1.6,  12.4],
+  'Burundi':                   [29.9,  -3.4],
+  'Cabo Verde':                [-24.0, 16.0],
+  'Cambodia':                  [104.9, 12.6],
+  'Cameroon':                  [12.4,   3.9],
+  'Canada':                    [-96.8, 56.1],
+  'Central African Republic':  [20.9,   6.6],
+  'Chad':                      [18.7,  15.5],
+  'Chile':                     [-71.5,-35.7],
+  'China':                     [104.2, 35.9],
+  'Colombia':                  [-74.3,  4.1],
+  'Comoros':                   [43.9, -11.6],
+  'Congo':                     [15.8,  -0.2],
+  'Costa Rica':                [-84.2,  9.7],
+  'Croatia':                   [15.5,  45.1],
+  'Cuba':                      [-79.5, 21.5],
+  'Cyprus':                    [33.4,  35.1],
+  'Czech Republic':            [15.5,  49.8],
+  'Denmark':                   [9.5,   56.3],
+  'Djibouti':                  [42.6,  11.8],
+  'Dominica':                  [-61.4, 15.4],
+  'Dominican Republic':        [-70.2, 18.7],
+  'Ecuador':                   [-77.8,  -1.8],
+  'Egypt':                     [30.8,  26.8],
+  'El Salvador':               [-88.9, 13.8],
+  'Equatorial Guinea':         [10.3,   1.7],
+  'Eritrea':                   [39.8,  15.2],
+  'Estonia':                   [25.0,  58.7],
+  'Eswatini':                  [31.5, -26.5],
+  'Ethiopia':                  [40.5,   9.1],
+  'Fiji':                      [178.1,-17.7],
+  'Finland':                   [25.7,  64.0],
+  'France':                    [2.3,   46.2],
+  'Gabon':                     [11.6,  -0.8],
+  'Gambia':                    [-15.3, 13.4],
+  'Georgia':                   [43.4,  42.3],
+  'Germany':                   [10.5,  51.2],
+  'Ghana':                     [-1.0,   7.9],
+  'Greece':                    [21.8,  39.1],
+  'Grenada':                   [-61.7, 12.1],
+  'Guatemala':                 [-90.2, 15.8],
+  'Guinea':                    [-11.3, 11.0],
+  'Guinea-Bissau':             [-15.2, 11.8],
+  'Guyana':                    [-58.9,  4.9],
+  'Haiti':                     [-72.3, 19.0],
+  'Honduras':                  [-86.6, 15.2],
+  'Hungary':                   [19.5,  47.0],
+  'Iceland':                   [-18.5, 64.9],
+  'India':                     [78.9,  20.6],
+  'Indonesia':                 [113.9, -0.8],
+  'Iran':                      [53.7,  32.4],
+  'Iraq':                      [43.7,  33.2],
+  'Ireland':                   [-8.2,  53.2],
+  'Israel':                    [34.9,  31.5],
+  'Italy':                     [12.5,  42.5],
+  'Jamaica':                   [-77.3, 18.1],
+  'Japan':                     [138.3, 36.2],
+  'Jordan':                    [36.2,  30.6],
+  'Kazakhstan':                [66.9,  48.0],
+  'Kenya':                     [37.9,   0.0],
+  'Kiribati':                  [-168.7, 1.9],
+  'Kuwait':                    [47.5,  29.3],
+  'Kyrgyzstan':                [74.6,  41.2],
+  'Laos':                      [102.5, 17.9],
+  'Latvia':                    [24.9,  56.9],
+  'Lebanon':                   [35.9,  33.9],
+  'Lesotho':                   [28.2, -29.6],
+  'Liberia':                   [-9.4,   6.4],
+  'Libya':                     [17.2,  26.3],
+  'Liechtenstein':             [9.6,   47.2],
+  'Lithuania':                 [23.9,  55.9],
+  'Luxembourg':                [6.1,   49.8],
+  'Madagascar':                [46.9, -18.8],
+  'Malawi':                    [34.3, -13.3],
+  'Malaysia':                  [109.7,  4.2],
+  'Maldives':                  [73.2,   3.2],
+  'Mali':                      [-1.7,  17.6],
+  'Malta':                     [14.4,  35.9],
+  'Marshall Islands':          [168.7,  7.1],
+  'Mauritania':                [-10.9, 20.3],
+  'Mauritius':                 [57.6, -20.3],
+  'Mexico':                    [-102.6, 23.6],
+  'Micronesia':                [150.5,  6.9],
+  'Moldova':                   [28.4,  47.4],
+  'Monaco':                    [7.4,   43.7],
+  'Mongolia':                  [103.8, 46.9],
+  'Montenegro':                [19.4,  42.7],
+  'Morocco':                   [-7.1,  31.8],
+  'Mozambique':                [35.5, -18.7],
+  'Myanmar':                   [96.7,  19.2],
+  'Namibia':                   [18.5, -22.0],
+  'Nauru':                     [166.9, -0.5],
+  'Nepal':                     [84.1,  28.4],
+  'Netherlands':               [5.3,   52.1],
+  'New Zealand':               [172.8,-41.0],
+  'Nicaragua':                 [-85.0, 12.8],
+  'Niger':                     [8.1,   16.1],
+  'Nigeria':                   [8.7,    9.1],
+  'North Korea':               [127.5, 40.3],
+  'North Macedonia':           [21.7,  41.6],
+  'Norway':                    [8.5,   65.5],
+  'Oman':                      [57.6,  21.5],
+  'Pakistan':                  [69.3,  30.4],
+  'Palau':                     [134.6,  7.5],
+  'Palestine':                 [35.3,  31.9],
+  'Panama':                    [-80.0,  8.6],
+  'Papua New Guinea':          [143.9, -6.3],
+  'Paraguay':                  [-58.4,-23.4],
+  'Peru':                      [-75.0,  -9.2],
+  'Philippines':               [122.9, 12.9],
+  'Poland':                    [19.1,  51.9],
+  'Portugal':                  [-8.2,  39.4],
+  'Qatar':                     [51.2,  25.4],
+  'Romania':                   [25.0,  46.0],
+  'Russia':                    [105.3, 61.5],
+  'Rwanda':                    [29.9,  -1.9],
+  'Saudi Arabia':              [45.1,  24.0],
+  'Senegal':                   [-14.5, 14.5],
+  'Serbia':                    [21.0,  44.0],
+  'Seychelles':                [55.5,  -4.6],
+  'Sierra Leone':              [-11.8,  8.6],
+  'Singapore':                 [103.8,  1.3],
+  'Slovakia':                  [19.7,  48.7],
+  'Slovenia':                  [14.8,  46.1],
+  'Solomon Islands':           [160.2, -9.6],
+  'Somalia':                   [46.2,   6.1],
+  'South Africa':              [25.1, -29.0],
+  'South Korea':               [127.8, 36.0],
+  'South Sudan':               [31.3,   7.0],
+  'Spain':                     [-3.7,  40.4],
+  'Sri Lanka':                 [80.7,   7.9],
+  'Sudan':                     [29.9,  12.9],
+  'Suriname':                  [-56.0,  4.0],
+  'Sweden':                    [18.6,  60.1],
+  'Switzerland':               [8.2,   46.8],
+  'Syria':                     [38.5,  35.0],
+  'Taiwan':                    [121.0, 23.7],
+  'Tajikistan':                [71.3,  38.9],
+  'Tanzania':                  [34.9,  -6.4],
+  'Thailand':                  [100.5, 15.9],
+  'Timor-Leste':               [125.7, -8.9],
+  'Togo':                      [0.8,    8.6],
+  'Tonga':                     [-175.2,-20.0],
+  'Trinidad and Tobago':       [-61.2, 10.7],
+  'Tunisia':                   [9.0,   34.0],
+  'Turkey':                    [35.2,  38.9],
+  'Turkmenistan':              [59.0,  39.0],
+  'Tuvalu':                    [178.1, -8.5],
+  'Uganda':                    [32.3,   1.4],
+  'Ukraine':                   [31.2,  48.4],
+  'United Arab Emirates':      [53.8,  24.0],
+  'United Kingdom':            [-3.4,  55.4],
+  'United States':             [-95.7, 37.1],
+  'Uruguay':                   [-55.8,-33.0],
+  'Uzbekistan':                [63.9,  41.4],
+  'Vanuatu':                   [167.0,-15.4],
+  'Vatican City':              [12.5,  41.9],
+  'Venezuela':                 [-66.6,  7.1],
+  'Vietnam':                   [108.3, 14.1],
+  'Yemen':                     [47.6,  15.6],
+  'Zambia':                    [27.8, -13.1],
+  'Zimbabwe':                  [29.9, -20.0],
+}
+
+const COUNTRY_EMOJI: Record<string, string> = {
+  'Afghanistan': '🫓', 'Albania': '🫒', 'Algeria': '🫕', 'Andorra': '🧀',
+  'Angola': '🍲', 'Antigua and Barbuda': '🦞', 'Argentina': '🥩', 'Armenia': '🍇',
+  'Australia': '🦘', 'Austria': '🥨', 'Azerbaijan': '🍢', 'Bahamas': '🦞',
+  'Bahrain': '🐟', 'Bangladesh': '🐟', 'Barbados': '🦞', 'Belarus': '🥔',
+  'Belgium': '🍟', 'Belize': '🌽', 'Benin': '🍲', 'Bhutan': '🌶️',
+  'Bolivia': '🌽', 'Bosnia and Herzegovina': '🥩', 'Botswana': '🥩', 'Brazil': '🥩',
+  'Brunei': '🍚', 'Bulgaria': '🥗', 'Burkina Faso': '🍲', 'Burundi': '🍌',
+  'Cabo Verde': '🐟', 'Cambodia': '🍜', 'Cameroon': '🍲', 'Canada': '🍁',
+  'Central African Republic': '🍲', 'Chad': '🍲', 'Chile': '🌶️', 'China': '🥟',
+  'Colombia': '🌮', 'Comoros': '🌴', 'Congo': '🍲', 'Costa Rica': '🌮',
+  'Croatia': '🐟', 'Cuba': '🥃', 'Cyprus': '🧀', 'Czech Republic': '🥨',
+  'Denmark': '🥐', 'Djibouti': '🍲', 'Dominica': '🌴', 'Dominican Republic': '🌴',
+  'Ecuador': '🍌', 'Egypt': '🧅', 'El Salvador': '🌮', 'Equatorial Guinea': '🍲',
+  'Eritrea': '🫓', 'Estonia': '🐟', 'Eswatini': '🍲', 'Ethiopia': '🫓',
+  'Fiji': '🌴', 'Finland': '🐟', 'France': '🥖', 'Gabon': '🍲',
+  'Gambia': '🍲', 'Georgia': '🍷', 'Germany': '🥨', 'Ghana': '🍲',
+  'Greece': '🫒', 'Grenada': '🌶️', 'Guatemala': '🌮', 'Guinea': '🍲',
+  'Guinea-Bissau': '🍲', 'Guyana': '🍚', 'Haiti': '🍲', 'Honduras': '🌮',
+  'Hungary': '🥘', 'Iceland': '🐟', 'India': '🍛', 'Indonesia': '🍚',
+  'Iran': '🍚', 'Iraq': '🫓', 'Ireland': '🥔', 'Israel': '🧆',
+  'Italy': '🍕', 'Jamaica': '🌶️', 'Japan': '🍣', 'Jordan': '🧆',
+  'Kazakhstan': '🥩', 'Kenya': '🫕', 'Kiribati': '🐟', 'Kuwait': '🫕',
+  'Kyrgyzstan': '🥩', 'Laos': '🍚', 'Latvia': '🐟', 'Lebanon': '🧆',
+  'Lesotho': '🍲', 'Liberia': '🍚', 'Libya': '🫕', 'Liechtenstein': '🧀',
+  'Lithuania': '🥔', 'Luxembourg': '🥩', 'Madagascar': '🍚', 'Malawi': '🍲',
+  'Malaysia': '🍜', 'Maldives': '🐟', 'Mali': '🍲', 'Malta': '🐟',
+  'Marshall Islands': '🐟', 'Mauritania': '🫕', 'Mauritius': '🍚', 'Mexico': '🌮',
+  'Micronesia': '🐟', 'Moldova': '🍷', 'Monaco': '🥐', 'Mongolia': '🥩',
+  'Montenegro': '🐟', 'Morocco': '🫕', 'Mozambique': '🐟', 'Myanmar': '🍜',
+  'Namibia': '🥩', 'Nauru': '🐟', 'Nepal': '🫕', 'Netherlands': '🧀',
+  'New Zealand': '🐑', 'Nicaragua': '🌮', 'Niger': '🍲', 'Nigeria': '🍲',
+  'North Korea': '🍚', 'North Macedonia': '🫒', 'Norway': '🐟', 'Oman': '🫕',
+  'Pakistan': '🫓', 'Palau': '🐟', 'Palestine': '🫒', 'Panama': '🌮',
+  'Papua New Guinea': '🍠', 'Paraguay': '🥩', 'Peru': '🍋', 'Philippines': '🍖',
+  'Poland': '🥣', 'Portugal': '🐟', 'Qatar': '🫕', 'Romania': '🥘',
+  'Russia': '🥣', 'Rwanda': '🍲', 'Saudi Arabia': '🫕', 'Senegal': '🐟',
+  'Serbia': '🥩', 'Seychelles': '🐟', 'Sierra Leone': '🍚', 'Singapore': '🍜',
+  'Slovakia': '🥣', 'Slovenia': '🧀', 'Solomon Islands': '🐟', 'Somalia': '🍚',
+  'South Africa': '🥩', 'South Korea': '🥩', 'South Sudan': '🍲', 'Spain': '🥘',
+  'Sri Lanka': '🍛', 'Sudan': '🫕', 'Suriname': '🍚', 'Sweden': '🐟',
+  'Switzerland': '🧀', 'Syria': '🫓', 'Taiwan': '🍜', 'Tajikistan': '🫓',
+  'Tanzania': '🍲', 'Thailand': '🍜', 'Timor-Leste': '🍚', 'Togo': '🍲',
+  'Tonga': '🌴', 'Trinidad and Tobago': '🌶️', 'Tunisia': '🫕', 'Turkey': '🍳',
+  'Turkmenistan': '🫓', 'Tuvalu': '🐟', 'Uganda': '🍌', 'Ukraine': '🥣',
+  'United Arab Emirates': '🫕', 'United Kingdom': '🐟', 'United States': '🍔',
+  'Uruguay': '🥩', 'Uzbekistan': '🫓', 'Vanuatu': '🌴', 'Vatican City': '🍷',
+  'Venezuela': '🌮', 'Vietnam': '🍲', 'Yemen': '🫕', 'Zambia': '🍲',
+  'Zimbabwe': '🍲',
+}
+
+interface ContentByCountry {
+  recipes: RecipeResponse[]
+  ingredients: IngredientResponse[]
+  techniques: TechniqueResponse[]
+}
+
+interface Props {
+  recipes: RecipeResponse[]
+  ingredients: IngredientResponse[]
+  techniques: TechniqueResponse[]
+}
+
+interface TooltipState {
+  x: number
+  y: number
+  country: string
+  content: ContentByCountry
+}
+
+export default function WorldMapSection({ recipes, ingredients, techniques }: Props) {
+  const [tooltip, setTooltip] = useState<TooltipState | null>(null)
+  const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const contentByCountry: Record<string, ContentByCountry> = {}
+  recipes.forEach((r) => {
+    if (!r.country) return
+    if (!contentByCountry[r.country]) contentByCountry[r.country] = { recipes: [], ingredients: [], techniques: [] }
+    contentByCountry[r.country].recipes.push(r)
+  })
+  ingredients.forEach((i) => {
+    if (!i.country) return
+    if (!contentByCountry[i.country]) contentByCountry[i.country] = { recipes: [], ingredients: [], techniques: [] }
+    contentByCountry[i.country].ingredients.push(i)
+  })
+  techniques.forEach((t) => {
+    if (!t.country) return
+    if (!contentByCountry[t.country]) contentByCountry[t.country] = { recipes: [], ingredients: [], techniques: [] }
+    contentByCountry[t.country].techniques.push(t)
+  })
+
+  const activeCountries = Object.keys(contentByCountry).filter((c) => COUNTRY_COORDS[c])
+
+  const clearHideTimer = () => {
+    if (hideTimer.current) {
+      clearTimeout(hideTimer.current)
+      hideTimer.current = null
+    }
+  }
+
+  const scheduleHide = () => {
+    clearHideTimer()
+    hideTimer.current = setTimeout(() => setTooltip(null), 220)
+  }
+
+  const handleMarkerEnter = useCallback((e: React.MouseEvent, country: string) => {
+    clearHideTimer()
+    const rect = (e.currentTarget as SVGElement).closest('svg')?.getBoundingClientRect()
+    const markerRect = (e.currentTarget as SVGElement).getBoundingClientRect()
+    if (!rect) return
+    setTooltip({
+      x: markerRect.left - rect.left + markerRect.width / 2,
+      y: markerRect.top - rect.top,
+      country,
+      content: contentByCountry[country],
+    })
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [contentByCountry])
+
+  const totalCount = (c: ContentByCountry) => c.recipes.length + c.ingredients.length + c.techniques.length
+
+  return (
+    <section>
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-base font-bold text-[#171433]">World Food Map</h2>
+        <span className="text-xs text-gray-400">{activeCountries.length} countries with content</span>
+      </div>
+
+      <div className="relative border border-[#d67ec9] rounded-xl bg-white overflow-hidden shadow-sm">
+        <ComposableMap
+          projection="geoMercator"
+          projectionConfig={{ scale: 130, center: [15, 20] }}
+          style={{ width: '100%', height: 'auto' }}
+          viewBox="0 0 800 420"
+        >
+          <Geographies geography={GEO_URL}>
+            {({ geographies }) =>
+              geographies.map((geo) => (
+                <Geography
+                  key={geo.rsmKey}
+                  geography={geo}
+                  style={{
+                    default: { fill: '#f0eaf2', stroke: '#d67ec9', strokeWidth: 0.4, outline: 'none' },
+                    hover:   { fill: '#ede8ee', stroke: '#8c2d9c', strokeWidth: 0.6, outline: 'none' },
+                    pressed: { fill: '#d67ec9', outline: 'none' },
+                  }}
+                />
+              ))
+            }
+          </Geographies>
+
+          {activeCountries.map((country) => {
+            const [lon, lat] = COUNTRY_COORDS[country]
+            const emoji = COUNTRY_EMOJI[country] ?? '🍽️'
+            return (
+              <Marker key={country} coordinates={[lon, lat]}>
+                <circle
+                  r={10}
+                  fill="#8c2d9c"
+                  fillOpacity={0.15}
+                  stroke="#8c2d9c"
+                  strokeWidth={1}
+                  style={{ cursor: 'pointer' }}
+                  onMouseEnter={(e) => handleMarkerEnter(e, country)}
+                  onMouseLeave={scheduleHide}
+                />
+                <text
+                  textAnchor="middle"
+                  dominantBaseline="central"
+                  fontSize={11}
+                  style={{ cursor: 'pointer', userSelect: 'none', pointerEvents: 'none' }}
+                >
+                  {emoji}
+                </text>
+              </Marker>
+            )
+          })}
+        </ComposableMap>
+
+        {tooltip && (
+          <div
+            className="absolute z-10"
+            style={{ left: tooltip.x, top: tooltip.y, transform: 'translate(-50%, calc(-100% - 12px))' }}
+            onMouseEnter={clearHideTimer}
+            onMouseLeave={scheduleHide}
+          >
+            <div className="bg-white border border-[#d67ec9] rounded-xl shadow-lg px-4 py-3 min-w-[180px] max-w-[240px]">
+              <p className="font-bold text-sm text-[#171433] mb-2">
+                {COUNTRY_EMOJI[tooltip.country] ?? '🍽️'} {tooltip.country}
+              </p>
+
+              {tooltip.content.recipes.length > 0 && (
+                <div className="mb-1">
+                  <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wide mb-0.5">Recipes</p>
+                  {tooltip.content.recipes.slice(0, 3).map((r) => (
+                    <Link
+                      key={r.id}
+                      to={`/recipes/${r.id}`}
+                      className="block text-xs text-gray-700 hover:text-[#8c2d9c] truncate py-0.5"
+                    >
+                      • {r.title}
+                    </Link>
+                  ))}
+                </div>
+              )}
+
+              {tooltip.content.ingredients.length > 0 && (
+                <div className="mb-1">
+                  <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wide mb-0.5">Ingredients</p>
+                  {tooltip.content.ingredients.slice(0, 3).map((i) => (
+                    <Link
+                      key={i.id}
+                      to={`/catalog/ingredients/${i.id}`}
+                      className="block text-xs text-gray-700 hover:text-[#8c2d9c] truncate py-0.5"
+                    >
+                      • {i.name}
+                    </Link>
+                  ))}
+                </div>
+              )}
+
+              {tooltip.content.techniques.length > 0 && (
+                <div className="mb-1">
+                  <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wide mb-0.5">Techniques</p>
+                  {tooltip.content.techniques.slice(0, 3).map((t) => (
+                    <Link
+                      key={t.id}
+                      to={`/catalog/techniques/${t.id}`}
+                      className="block text-xs text-gray-700 hover:text-[#8c2d9c] truncate py-0.5"
+                    >
+                      • {t.name}
+                    </Link>
+                  ))}
+                </div>
+              )}
+
+              <Link
+                to={`/search?q=${encodeURIComponent(tooltip.country)}`}
+                className="mt-2 flex items-center justify-between text-xs font-semibold text-[#8c2d9c] hover:text-[#7a2589] border-t border-gray-100 pt-2"
+              >
+                <span>{totalCount(tooltip.content)} item{totalCount(tooltip.content) !== 1 ? 's' : ''}</span>
+                <span>Explore {tooltip.country} →</span>
+              </Link>
+            </div>
+            <div className="w-3 h-3 bg-white border-r border-b border-[#d67ec9] rotate-45 mx-auto -mt-1.5" />
+          </div>
+        )}
+
+        <div className="absolute bottom-3 left-3 flex items-center gap-2 bg-white/80 backdrop-blur-sm border border-gray-200 rounded-lg px-3 py-1.5">
+          <div className="w-3 h-3 rounded-full bg-[#8c2d9c] opacity-60" />
+          <span className="text-xs text-gray-500">Hover a marker to preview · click to explore</span>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/culinarygraph-frontend/src/features/search/SearchPage.tsx
+++ b/culinarygraph-frontend/src/features/search/SearchPage.tsx
@@ -1,29 +1,65 @@
-import { useSearchParams, Link } from 'react-router-dom'
+import { useSearchParams, Link, useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { useMemo } from 'react'
+import { useMemo, useState, useEffect } from 'react'
 import { fetchIngredients, fetchTechniques } from '../catalog/catalogApi'
 import { fetchRecipes } from '../recipe/recipeApi'
 
+function matchesQuery(fields: (string | null | undefined)[], q: string): boolean {
+  return fields.some((f) => f?.toLowerCase().includes(q))
+}
+
 export default function SearchPage() {
   const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
   const initialQ = searchParams.get('q') ?? ''
+  const [inputValue, setInputValue] = useState(initialQ)
 
-  const { data: ingredients } = useQuery({ queryKey: ['catalog', 'ingredients'], queryFn: fetchIngredients })
-  const { data: techniques } = useQuery({ queryKey: ['catalog', 'techniques'], queryFn: fetchTechniques })
-  const { data: recipes } = useQuery({ queryKey: ['recipes'], queryFn: fetchRecipes })
+  useEffect(() => { setInputValue(initialQ) }, [initialQ])
+
+  const { data: ingredients } = useQuery({ queryKey: ['catalog', 'ingredients'], queryFn: fetchIngredients, staleTime: 0 })
+  const { data: techniques } = useQuery({ queryKey: ['catalog', 'techniques'], queryFn: fetchTechniques, staleTime: 0 })
+  const { data: recipes } = useQuery({ queryKey: ['recipes'], queryFn: fetchRecipes, staleTime: 0 })
 
   const q = initialQ.trim().toLowerCase()
 
   const results = useMemo(() => ({
-    recipes: (recipes ?? []).filter((r) => r.title.toLowerCase().includes(q)),
-    techniques: (techniques ?? []).filter((t) => t.name.toLowerCase().includes(q)),
-    ingredients: (ingredients ?? []).filter((i) => i.name.toLowerCase().includes(q)),
+    recipes: (recipes ?? []).filter((r) =>
+      matchesQuery([r.title, r.description, r.country, r.region, ...(r.tags ?? [])], q)
+    ),
+    techniques: (techniques ?? []).filter((t) =>
+      matchesQuery([t.name, t.description, t.country, t.region, t.culturalNotes, t.prerequisites], q)
+    ),
+    ingredients: (ingredients ?? []).filter((i) =>
+      matchesQuery([i.name, i.description, i.country, i.region, ...(i.seasons ?? []), ...(i.substitutes ?? [])], q)
+    ),
   }), [q, recipes, techniques, ingredients])
 
   const total = results.recipes.length + results.techniques.length + results.ingredients.length
 
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (inputValue.trim()) navigate(`/search?q=${encodeURIComponent(inputValue.trim())}`)
+  }
+
   return (
     <div className="max-w-3xl mx-auto px-6 py-8 space-y-6">
+
+      {/* Search input */}
+      <form onSubmit={handleSearch} className="flex gap-2">
+        <input
+          type="text"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          placeholder="Search by name, country, tags…"
+          className="flex-1 border border-gray-300 rounded-lg px-4 py-2 text-sm focus:outline-none focus:border-[#8c2d9c] focus:ring-1 focus:ring-[#8c2d9c]"
+        />
+        <button
+          type="submit"
+          className="bg-[#8c2d9c] text-white text-sm font-medium px-5 py-2 rounded-lg hover:bg-[#7a2589] transition-colors"
+        >
+          Search
+        </button>
+      </form>
 
       {/* Result count */}
       {q && (
@@ -37,7 +73,7 @@ export default function SearchPage() {
 
       {q && total === 0 && (
         <div className="text-center py-16 text-gray-400 text-sm">
-          Try a different keyword.
+          Try a different keyword, country name, or tag.
         </div>
       )}
 
@@ -48,13 +84,24 @@ export default function SearchPage() {
             {results.recipes.map((r) => (
               <li key={r.id}>
                 <Link to={`/recipes/${r.id}`}
-                  className="flex items-center gap-3 px-4 py-3 hover:bg-[#fdf8ff] transition-colors group">
-                  <span className="text-xs bg-[#ede8ee] text-[#8c2d9c] px-2 py-0.5 rounded font-medium flex-shrink-0">Recipe</span>
-                  <span className="text-sm font-medium text-[#171433] group-hover:text-[#8c2d9c] truncate">{r.title}</span>
-                  {(r.country || r.region) && (
-                    <span className="text-xs text-gray-400 ml-auto flex-shrink-0">
-                      {[r.country, r.region].filter(Boolean).join(', ')}
-                    </span>
+                  className="flex flex-col gap-1 px-4 py-3 hover:bg-[#fdf8ff] transition-colors group">
+                  <div className="flex items-center gap-3">
+                    <span className="text-xs bg-[#ede8ee] text-[#8c2d9c] px-2 py-0.5 rounded font-medium flex-shrink-0">Recipe</span>
+                    <span className="text-sm font-medium text-[#171433] group-hover:text-[#8c2d9c] truncate">{r.title}</span>
+                    {(r.country || r.region) && (
+                      <span className="text-xs text-gray-400 ml-auto flex-shrink-0">
+                        {[r.country, r.region].filter(Boolean).join(', ')}
+                      </span>
+                    )}
+                  </div>
+                  {r.tags && r.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-1 pl-1">
+                      {r.tags.map((tag) => (
+                        <span key={tag} className="text-[10px] bg-gray-100 text-gray-500 px-1.5 py-0.5 rounded">
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
                   )}
                 </Link>
               </li>
@@ -92,13 +139,24 @@ export default function SearchPage() {
             {results.ingredients.map((i) => (
               <li key={i.id}>
                 <Link to={`/catalog/ingredients/${i.id}`}
-                  className="flex items-center gap-3 px-4 py-3 hover:bg-[#fdf8ff] transition-colors group">
-                  <span className="text-xs bg-[#ede8ee] text-[#8c2d9c] px-2 py-0.5 rounded font-medium flex-shrink-0">Ingredient</span>
-                  <span className="text-sm font-medium text-[#171433] group-hover:text-[#8c2d9c] truncate">{i.name}</span>
-                  {(i.country || i.region) && (
-                    <span className="text-xs text-gray-400 ml-auto flex-shrink-0">
-                      {[i.country, i.region].filter(Boolean).join(', ')}
-                    </span>
+                  className="flex flex-col gap-1 px-4 py-3 hover:bg-[#fdf8ff] transition-colors group">
+                  <div className="flex items-center gap-3">
+                    <span className="text-xs bg-[#ede8ee] text-[#8c2d9c] px-2 py-0.5 rounded font-medium flex-shrink-0">Ingredient</span>
+                    <span className="text-sm font-medium text-[#171433] group-hover:text-[#8c2d9c] truncate">{i.name}</span>
+                    {(i.country || i.region) && (
+                      <span className="text-xs text-gray-400 ml-auto flex-shrink-0">
+                        {[i.country, i.region].filter(Boolean).join(', ')}
+                      </span>
+                    )}
+                  </div>
+                  {i.seasons && i.seasons.length > 0 && (
+                    <div className="flex flex-wrap gap-1 pl-1">
+                      {i.seasons.map((s) => (
+                        <span key={s} className="text-[10px] bg-gray-100 text-gray-500 px-1.5 py-0.5 rounded">
+                          {s.toLowerCase()}
+                        </span>
+                      ))}
+                    </div>
                   )}
                 </Link>
               </li>

--- a/culinarygraph-frontend/src/react-simple-maps.d.ts
+++ b/culinarygraph-frontend/src/react-simple-maps.d.ts
@@ -1,0 +1,46 @@
+declare module 'react-simple-maps' {
+  import type { ReactNode, SVGProps } from 'react'
+
+  interface ComposableMapProps extends SVGProps<SVGSVGElement> {
+    projection?: string
+    projectionConfig?: Record<string, unknown>
+    viewBox?: string
+    style?: React.CSSProperties
+    children?: ReactNode
+  }
+  export function ComposableMap(props: ComposableMapProps): JSX.Element
+
+  interface ZoomableGroupProps {
+    center?: [number, number]
+    zoom?: number
+    children?: ReactNode
+  }
+  export function ZoomableGroup(props: ZoomableGroupProps): JSX.Element
+
+  interface GeographiesProps {
+    geography: string | Record<string, unknown>
+    children: (args: { geographies: GeoFeature[] }) => ReactNode
+  }
+  export function Geographies(props: GeographiesProps): JSX.Element
+
+  interface GeoFeature {
+    rsmKey: string
+    [key: string]: unknown
+  }
+
+  interface GeographyProps extends SVGProps<SVGPathElement> {
+    geography: GeoFeature
+    style?: {
+      default?: React.CSSProperties
+      hover?: React.CSSProperties
+      pressed?: React.CSSProperties
+    }
+  }
+  export function Geography(props: GeographyProps): JSX.Element
+
+  interface MarkerProps extends SVGProps<SVGGElement> {
+    coordinates: [number, number]
+    children?: ReactNode
+  }
+  export function Marker(props: MarkerProps): JSX.Element
+}


### PR DESCRIPTION
- World map on homepage with markers for all countries in the country                                                            
    list; hover tooltip shows content preview with clickable links to                                                              
    detail pages; "Explore [country] →" navigates to search results                                                                
- Tooltip is sticky (delayed hide timer) so mouse can reach it                                                                   
- staleTime: 0 on homepage queries so newly added countries appear                                                               
    without a page reload                                                                                                          
- Search now matches across name/title, description, country, region,                                                            
    tags (recipes), and seasons/substitutes (ingredients)                                                                          
- SearchPage gains its own input field for refining queries in-place 

closes #41 